### PR TITLE
Change PIN_RESET to uint8_t and value to 0 (not D3)

### DIFF
--- a/src/Homie/Constants.hpp
+++ b/src/Homie/Constants.hpp
@@ -10,7 +10,7 @@ namespace HomieInternals {
   const uint16_t DEFAULT_HOMIE_OTA_PORT = 35590;
   const char DEFAULT_HOMIE_OTA_PATH[] = "/ota";
 
-  const float PIN_RESET = D3;
+  const uint8_t PIN_RESET = 0; // == D3 on nodeMCU
 
   const float LED_WIFI_DELAY = 1;
   const float LED_MQTT_DELAY = 0.2;


### PR DESCRIPTION
One line PR.

D3 (== GPIO0) is not defined when you are not using NodeMCU board in the arduino IDE, so you get a compilation error.

I guess float instead of uint was a copy past mistake...

Bytheway, I'm thinking to make this reset a bit more configurable... at least the PIN, but maybe also the "delay". An other way is to expose a function to manually trigger the reset from main code...