### PR TITLE
Verify if fingerprint is NOT empty

### DIFF
--- a/src/Homie/Boot/BootNormal.cpp
+++ b/src/Homie/Boot/BootNormal.cpp
@@ -73,7 +73,7 @@ void BootNormal::_mqttConnect() {
   }
 
   if (connectResult) {
-    if (Config.get().mqtt.ssl && !strcmp(Config.get().mqtt.fingerprint, "")) {
+    if (Config.get().mqtt.ssl && strcmp(Config.get().mqtt.fingerprint, "")) {
       if(!this->_wifiClientSecure.verify(Config.get().mqtt.fingerprint, Config.get().mqtt.host)) {
         Logger.logln("✖ MQTT SSL certificate mismatch");
         this->_interface->mqtt->disconnect();


### PR DESCRIPTION
I believe the logic is wrong: verification should be performed if the fingerprint string is not empty.
Addresses #42