### PR TITLE
replaced function pointer with function object

### DIFF
--- a/src/Homie/Datatypes/Callbacks.hpp
+++ b/src/Homie/Datatypes/Callbacks.hpp
@@ -1,13 +1,14 @@
 #pragma once
 
 #include "../../HomieEvent.h"
+#include <functional>
 
 namespace HomieInternals {
   typedef void (*OperationFunction)();
 
   typedef bool (*GlobalInputHandler)(String nodeId, String property, String value);
   typedef bool (*NodeInputHandler)(String property, String value);
-  typedef bool (*PropertyInputHandler)(String value);
+  typedef std::function<bool(String)> PropertyInputHandler;
 
   typedef void (*EventHandler)(HomieEvent event);
 


### PR DESCRIPTION
I'm working on a sensor network projekt, using your excellent Homie framework. I have different sensors (light, temperature), and some actors (led, relay). I modularized my code, so I have a class for every kind of device. And I'm unable to subscribe my HomieNodes to topics when I'm inside of a method.

The problem is, that `HomieNode.subscribe()` only takes a function pointer as a second parameter, which I'm unable to provide. I'd rather give a function object.

With this change I'm able to subscribe my method `ledOnHandler()` in one of these two ways:
```
ledNode.subscribe("on", [this](String value) { return ledOnHandler(value); });
ledNode.subscribe("on", std::bind(&DeviceLed::ledOnHandler, this, std::placeholders::_1));
```
I successfully tested that the old way of doing this still works:
```
ledNode.subscribe("on", ledOnHandler);
```
So I don't think that this change breaks anything.

To be honest, I didn't make this change myself. I had a friend helping me, who is far more used to write code in C++. To me, this looks even stranger than usual... ;-)

I'd be happy to learn that there is another way to register, so that this change is obsolete. Please tell me if you know something. Thanks in advance!