### PR TITLE
publish compile date and time

### DIFF
--- a/src/Homie/Boot/BootNormal.cpp
+++ b/src/Homie/Boot/BootNormal.cpp
@@ -169,6 +169,9 @@ void BootNormal::_mqttSetup() {
   this->_fillMqttTopic(PSTR("/$fwversion"));
   if (!this->_publishRetainedOrFail(this->_interface->firmware.version)) return;
 
+  this->_fillMqttTopic(PSTR("/$fwcompiled"));
+  if (!this->_publishRetainedOrFail(__DATE__ " - " __TIME__)) return;
+
   this->_interface->logger->logln(F(" OK"));
 
   this->_fillMqttTopic(PSTR("/+/+/set"));


### PR DESCRIPTION
At first: feel free to reject this request, I'm not sure if anybody else would have a use for this.

It happened several times to me that I got confused when updating my Homie devices over the air. Turned out that I repeatedly flashed the same old firmware, which of course didn't work as I expected. I changed the firmware version, just to see in `/$fwversion` if it got changed.

So I found out that gcc sets some default macros that contain time and date of the compilation -- `__DATE__` and `__TIME__`. At least for me, it would be nice to see that in MQTT messages. I tried putting it in `setFirmware()`, but the function doesn't take such a long string. So I put these two lines into the code, now I get a message like this:

```devices/01234567/$fwcompiled Apr 23 2016 - 00:36:02```

Again: this relieves my personal problem. Feel free to reject the request. Or tell me if you want me to do something else before you're going to accept it.