### PR TITLE
Add several virtual methods to HomieNode

### DIFF
--- a/src/Homie.cpp
+++ b/src/Homie.cpp
@@ -127,7 +127,7 @@ void HomieClass::setBrand(const char* name) {
   strcpy(this->_interface.brand, name);
 }
 
-void HomieClass::registerNode(const HomieNode& node) {
+void HomieClass::registerNode(HomieNode& node) {
   this->_checkBeforeSetup(F("registerNode"));
   if (this->_interface.registeredNodesCount > MAX_REGISTERED_NODES_COUNT) {
     Serial.println(F("✖ register(): the max registered nodes count has been reached"));

--- a/src/Homie.hpp
+++ b/src/Homie.hpp
@@ -27,7 +27,7 @@ namespace HomieInternals {
       void setLedPin(unsigned char pin, unsigned char on);
       void setBrand(const char* name);
       void setFirmware(const char* name, const char* version);
-      void registerNode(const HomieNode& node);
+      void registerNode(HomieNode& node);
       void setGlobalInputHandler(GlobalInputHandler globalInputHandler);
       void setResettable(bool resettable);
       void onEvent(EventHandler handler);

--- a/src/Homie/Datatypes/Interface.hpp
+++ b/src/Homie/Datatypes/Interface.hpp
@@ -34,7 +34,7 @@ namespace HomieInternals {
       ResetFunction userFunction;
     } reset;
 
-    const HomieNode* registeredNodes[MAX_REGISTERED_NODES_COUNT];
+    HomieNode* registeredNodes[MAX_REGISTERED_NODES_COUNT];
     unsigned char registeredNodesCount;
 
     GlobalInputHandler globalInputHandler;

--- a/src/HomieNode.cpp
+++ b/src/HomieNode.cpp
@@ -34,6 +34,10 @@ void HomieNode::subscribe(const char* property, PropertyInputHandler inputHandle
   this->_subscriptions[this->_subscriptionsCount++] = subscription;
 }
 
+bool HomieNode::handleInput(String const &property, String const &value) {
+  return this->_inputHandler(property, value);
+}
+
 const char* HomieNode::getId() const {
   return this->_id;
 }
@@ -52,8 +56,4 @@ unsigned char HomieNode::getSubscriptionsCount() const {
 
 bool HomieNode::getSubscribeToAll() const {
   return this->_subscribeToAll;
-}
-
-NodeInputHandler HomieNode::getInputHandler() const {
-  return this->_inputHandler;
 }

--- a/src/HomieNode.hpp
+++ b/src/HomieNode.hpp
@@ -20,13 +20,21 @@ class HomieNode {
 
     void subscribe(const char* property, HomieInternals::PropertyInputHandler inputHandler = [](String value) { return false; });
 
+  protected:
+    virtual void setup() {}
+
+    virtual void loop() {}
+
+    virtual void onReadyToOperate() {}
+
+    virtual bool handleInput(String const &property, String const &value);
+
   private:
     const char* getId() const;
     const char* getType() const;
     const HomieInternals::Subscription* getSubscriptions() const;
     unsigned char getSubscriptionsCount() const;
     bool getSubscribeToAll() const;
-    HomieInternals::NodeInputHandler getInputHandler() const;
 
     const char* _id;
     const char* _type;


### PR DESCRIPTION
This is an alternate implementation of @euphi idea.
I've removed all the non essential editions (serial flush on some errors, disable mDNS) and I've added the onReadyToOperate() virtual method I proposed in my previous merge request.

