### PR TITLE
Adds Homie::publishProperty

### DIFF
--- a/src/Homie.cpp
+++ b/src/Homie.cpp
@@ -211,4 +211,31 @@ bool HomieClass::setNodeProperty(const HomieNode& node, const char* property, co
   return this->_mqttClient.publish(value, retained);
 }
 
+bool HomieClass::publishRaw(const char* topic, const char* value, bool retained) {
+  if (!this->isReadyToOperate()) {
+    this->_logger.logln(F("✖ publishRaw(): impossible now"));
+    return false;
+  }
+  auto topiclen = strlen(topic);
+  if (5 + 2 + topiclen + strlen(value) + 1 > MQTT_MAX_PACKET_SIZE) {
+    this->_logger.logln(F("✖ publishRaw(): content to send is too long"));
+    return false;
+  }
+  auto &cli = this->_mqttClient;
+  auto buf = cli.getTopicBuffer();
+  memcpy(buf, topic, topiclen + 1);
+  return cli.publish(value, retained);
+}
+
+String HomieClass::getNodeTopic(const char* nodeId, const char* deviceId)
+{
+  String topic(64);
+  topic = this->_config.get().mqtt.baseTopic;
+  topic.concat(deviceId ? deviceId : getId());
+  topic.concat('/');
+  topic.concat(nodeId);
+  topic.concat('/');
+  return topic;
+}
+
 HomieClass Homie;

--- a/src/Homie.hpp
+++ b/src/Homie.hpp
@@ -41,6 +41,10 @@ namespace HomieInternals {
         return this->setNodeProperty(node, property.c_str(), value.c_str(), retained);
       }
       bool setNodeProperty(const HomieNode& node, const char* property, const char* value, bool retained = true);
+      bool publishRaw(const char* topic, const char* value, bool retained = true);
+      String getNodeTopic(const char* nodeId, const char* deviceId = 0); 
+      inline const char *getId() const;
+
     private:
       bool _setupCalled;
       Boot* _boot;
@@ -55,6 +59,9 @@ namespace HomieInternals {
 
       void _checkBeforeSetup(const __FlashStringHelper* functionName);
   };
+  const char *HomieClass::getId() const {
+    return this->_config.get().deviceId;
+  }
 }
 
 extern HomieInternals::HomieClass Homie;

--- a/src/Homie/Config.cpp
+++ b/src/Homie/Config.cpp
@@ -182,10 +182,6 @@ bool Config::load() {
   return true;
 }
 
-const ConfigStruct& Config::get() {
-  return this->_configStruct;
-}
-
 void Config::erase() {
   if (!this->_spiffsBegin()) { return; }
 

--- a/src/Homie/Config.hpp
+++ b/src/Homie/Config.hpp
@@ -14,7 +14,7 @@ namespace HomieInternals {
       Config();
       void attachInterface(Interface* interface);
       bool load();
-      const ConfigStruct& get();
+      inline const ConfigStruct& get() const;
       void erase();
       void write(const String& config);
       void setOtaMode(bool enabled, const char* version = "");
@@ -31,4 +31,9 @@ namespace HomieInternals {
 
       bool _spiffsBegin();
   };
+
+  const ConfigStruct& Config::get() const {
+    return this->_configStruct;
+  }
+
 }

--- a/src/HomieNode.cpp
+++ b/src/HomieNode.cpp
@@ -38,14 +38,6 @@ bool HomieNode::handleInput(String const &property, String const &value) {
   return this->_inputHandler(property, value);
 }
 
-const char* HomieNode::getId() const {
-  return this->_id;
-}
-
-const char* HomieNode::getType() const {
-  return this->_type;
-}
-
 const Subscription* HomieNode::getSubscriptions() const {
   return this->_subscriptions;
 }

--- a/src/HomieNode.hpp
+++ b/src/HomieNode.hpp
@@ -18,6 +18,10 @@ class HomieNode {
   public:
     HomieNode(const char* id, const char* type, HomieInternals::NodeInputHandler nodeInputHandler = [](String property, String value) { return false; }, bool subscribeToAll = false);
 
+    const char* getId() const { return this->_id; }
+
+    const char* getType() const { return this->_type; }
+
     void subscribe(const char* property, HomieInternals::PropertyInputHandler inputHandler = [](String value) { return false; });
 
   protected:
@@ -30,8 +34,6 @@ class HomieNode {
     virtual bool handleInput(String const &property, String const &value);
 
   private:
-    const char* getId() const;
-    const char* getType() const;
     const HomieInternals::Subscription* getSubscriptions() const;
     unsigned char getSubscriptionsCount() const;
     bool getSubscribeToAll() const;


### PR DESCRIPTION
This method allow to publish properties for foreign objects.
For example, a switch can publish a property turning on a light.