### PR TITLE
Transparent proxy for captive portal custom configurations

### DIFF
--- a/docs/6.-Configuration-API.md
+++ b/docs/6.-Configuration-API.md
@@ -131,3 +131,81 @@ See [JSON configuration file](5.-JSON-configuration-file.md).
 ```json
 { "success": false, "error": "Device already configured" }
 ```
+
+
+#### POST `/wifi-connect`
+
+Initiates the connection of the device to the wifi network while in config mode. This request is not synchronous and the result (wifi connected or not) must be obtained by "/wifi-status".
+
+##### Request params
+
+ssid - wifi ssid network name
+
+password - wifi password
+
+##### Response
+
+* In case of success:
+
+202 Accepted (application/json)
+
+```json
+{ "success": true }
+```
+
+* In case of error in the payload:
+
+400 Bad Request (application/json)
+
+```json
+{ "success": false, "error": "[Reason why the payload is invalid]" }
+```
+
+
+#### GET `/wifi-status`
+
+Returns the current wifi connection status.
+
+Helpful when monitoring Wifi connectivity after sending ssid/password and waiting for an answer.
+
+##### Request params
+
+None
+
+##### Response
+
+* In case of success:
+
+200 OK (application/json)
+
+```json
+{ "status": "[status of wifi connection]" }
+```
+
+
+
+#### POST `/proxy-control`
+
+Enable/disable the device to act as a transparent proxy between AP and Station networks.
+
+All requests that don't collide with existing api paths will be bridged to the destination according to the "Host" header in http. The destination host is called using the existing Wifi connection (Station Mode established after ssid/password is configured in "/wifi-connect") and all contents are bridged back to the connection made to the AP side.
+
+This feature can be used to help captive portals to perform cloud api calls during device enrollment using the esp wifi ap connection without having to patch the Homie firmware. By using the transparent proxy, all operations can be performed by the custom javascript running on the browser (/data/homie/ui_bundle.gz)
+
+https is not supported.
+
+Important: The http request and responses must be kept as small as possible because all contents are transported using ram memory, which is very limited.
+
+##### Request params
+
+enable - true or false indicating if the device has to bridge all unknown requests to the Internet (transparent proxy activated) or not.
+
+##### Response
+
+* In case of success:
+
+200 OK (application/json)
+
+```json
+{ "message": "[proxy-enabled|proxy-disabled]" }
+```

--- a/src/Homie/Boot/BootConfig.cpp
+++ b/src/Homie/Boot/BootConfig.cpp
@@ -72,10 +72,10 @@ void BootConfig::_onWifiConnectRequest() {
   if(ssid && pass && ssid!="" && pass!= "") {
     this->_interface->logger->logln(F("Connecting to WiFi"));
     WiFi.begin(ssid.c_str(), pass.c_str());
-    this->_http.send(202, "application/json", "{\"message\":\"wifi-connect-started\"}");
+    this->_http.send(202, "application/json", "{\"success\":true}");
   } else {
     this->_interface->logger->logln(F("ssid/password required"));
-    this->_http.send(400, "application/json", "{\"message\":\"ssid-password-required\"}");
+    this->_http.send(400, "application/json", "{\"success\":false, \"error\":\"ssid-password-required\"}");
   }
 }
 

--- a/src/Homie/Boot/BootConfig.cpp
+++ b/src/Homie/Boot/BootConfig.cpp
@@ -11,6 +11,7 @@ BootConfig::BootConfig()
 , _jsonWifiNetworks()
 , _flaggedForReboot(false)
 , _flaggedForRebootAt(0)
+, _proxyEnabled(false)
 {
   this->_wifiScanTimer.setInterval(CONFIG_SCAN_INTERVAL);
 }
@@ -30,7 +31,7 @@ void BootConfig::setup() {
   this->_interface->logger->log(F("Device ID is "));
   this->_interface->logger->logln(deviceId);
 
-  WiFi.mode(WIFI_AP);
+  WiFi.mode(WIFI_AP_STA);
 
   char apName[MAX_WIFI_SSID_LENGTH];
   strcpy(apName, this->_interface->brand);
@@ -57,8 +58,62 @@ void BootConfig::setup() {
     this->_interface->logger->logln(F("Received CORS request for /config"));
     this->_http.sendContent(FPSTR(PROGMEM_CONFIG_CORS));
   });
+  this->_http.on("/wifi-connect", HTTP_POST, std::bind(&BootConfig::_onWifiConnectRequest, this));
+  this->_http.on("/wifi-status", HTTP_GET, std::bind(&BootConfig::_onWifiStatusRequest, this));
+  this->_http.on("/proxy-control", HTTP_POST, std::bind(&BootConfig::_onProxyControlRequest, this));
   this->_http.onNotFound(std::bind(&BootConfig::_onCaptivePortal, this));
   this->_http.begin();
+}
+
+void BootConfig::_onWifiConnectRequest() {
+  this->_interface->logger->logln(F("Received wifi connect request"));
+  String ssid = this->_http.arg("ssid");
+  String pass = this->_http.arg("password");
+  if(ssid && pass && ssid!="" && pass!= "") {
+    this->_interface->logger->logln(F("Connecting to WiFi"));
+    WiFi.begin(ssid.c_str(), pass.c_str());
+    this->_http.send(202, "application/json", "{\"message\":\"wifi-connect-started\"}");
+  } else {
+    this->_interface->logger->logln(F("ssid/password required"));
+    this->_http.send(400, "application/json", "{\"message\":\"ssid-password-required\"}");
+  }
+}
+
+void BootConfig::_onWifiStatusRequest() {
+  this->_interface->logger->logln(F("Received wifi status request"));
+  String json = "";
+  switch (WiFi.status()) {
+    case WL_IDLE_STATUS:
+      json = "{\"status\":\"idle\"}"; break;
+    case WL_CONNECT_FAILED:
+      json = "{\"status\":\"connect-failed\"}"; break;
+    case WL_CONNECTION_LOST:
+      json = "{\"status\":\"connection-lost\"}"; break;
+    case WL_NO_SSID_AVAIL:
+      json = "{\"status\":\"no-ssid-avail\"}"; break;
+    case WL_CONNECTED:
+      json = "{\"status\":\"connected\", \"ip\":\""+ WiFi.localIP().toString() +"\"}"; break;
+    case WL_DISCONNECTED:
+      json = "{\"status\":\"disconnected\"}"; break;
+    default:
+      json = "{\"status\":\"other\"}"; break;
+  }
+  this->_interface->logger->log(F("WiFi status "));
+  this->_interface->logger->logln(json);
+  this->_http.send(200, "application/json", json);
+}
+
+void BootConfig::_onProxyControlRequest() {
+  this->_interface->logger->logln(F("Received proxy control request"));
+  String enable = this->_http.arg("enable");
+  this->_proxyEnabled = (enable == "true");
+  if(this->_proxyEnabled) {
+    this->_http.send(200, "application/json", "{\"message\":\"proxy-enabled\"}");
+  } else {
+    this->_http.send(200, "application/json", "{\"message\":\"proxy-disabled\"}");
+  }
+  this->_interface->logger->log(F("Transparent proxy enabled="));
+  this->_interface->logger->logln(this->_proxyEnabled);
 }
 
 void BootConfig::_generateNetworksJson() {
@@ -106,12 +161,18 @@ void BootConfig::_generateNetworksJson() {
 void BootConfig::_onCaptivePortal() {
   String host = this->_http.hostHeader();
   if (host && !host.equalsIgnoreCase(F("homie.config"))) {
-    this->_interface->logger->logln(F("Received captive portal request"));
-    // Catch any captive portal probe.
-    // Every browser brand uses a different URL for this purpose
-    // We MUST redirect all them to local webserver to prevent cache poisoning
-    this->_http.sendHeader(F("Location"), F("http://homie.config/"));
-    this->_http.send(302, F("text/plain"), F(""));
+    //redirect unknown host requests to self if not connected to Internet yet
+    if(!this->_proxyEnabled) {
+      this->_interface->logger->logln(F("Received captive portal request"));
+      // Catch any captive portal probe.
+      // Every browser brand uses a different URL for this purpose
+      // We MUST redirect all them to local webserver to prevent cache poisoning
+      this->_http.sendHeader(F("Location"), F("http://homie.config/"));
+      this->_http.send(302, F("text/plain"), F(""));
+    //perform transparent proxy to Internet if connected
+    } else {
+      this->_proxyHttpRequest();
+    }
   } else if (this->_http.uri() != "/" || !SPIFFS.exists(CONFIG_UI_BUNDLE_PATH)) {
     this->_interface->logger->logln(F("Received not found request"));
     this->_http.send(404, F("text/plain"), F("UI bundle not loaded. See Configuration API usage: http://marvinroger.viewdocs.io/homie-esp8266/6.-Configuration-API"));
@@ -121,6 +182,41 @@ void BootConfig::_onCaptivePortal() {
     size_t sent = this->_http.streamFile(file, F("text/html"));
     file.close();
   }
+}
+
+void BootConfig::_proxyHttpRequest() {
+  this->_interface->logger->logln(F("Received transparent proxy request"));
+
+  //send request to destination (as in incoming host header)
+  this->_httpClient.setUserAgent("ESP8266-Homie");
+  this->_httpClient.begin("http://" + this->_http.hostHeader() + this->_http.uri());
+  //copy headers
+  for(int i=0; i<this->_http.headers(); i++) {
+    this->_httpClient.addHeader(this->_http.headerName(i), this->_http.header(i));
+  }
+
+  String method = "";
+  switch(this->_http.method()) {
+    case HTTP_GET: method = "GET"; break;
+    case HTTP_PUT: method = "PUT"; break;
+    case HTTP_POST: method = "POST"; break;
+    case HTTP_DELETE: method = "DELETE"; break;
+    case HTTP_OPTIONS: method = "OPTIONS"; break;
+  }
+
+  this->_interface->logger->logln(F("Proxy sent request to destination"));
+  int _httpCode = this->_httpClient.sendRequest(method.c_str(), this->_http.arg("plain"));
+  this->_interface->logger->log(F("Destination response code="));
+  this->_interface->logger->logln(_httpCode);
+
+  //bridge response to browser
+  //copy response headers
+  for(int i=0; i<this->_httpClient.headers(); i++) {
+    this->_http.sendHeader(this->_httpClient.headerName(i), this->_httpClient.header(i), false);
+  }
+  this->_interface->logger->logln(F("Bridging received destination contents to client"));
+  this->_http.send(_httpCode, this->_httpClient.header("Content-Type"), this->_httpClient.getString());
+  this->_httpClient.end();
 }
 
 void BootConfig::_onDeviceInfoRequest() {

--- a/src/Homie/Boot/BootConfig.hpp
+++ b/src/Homie/Boot/BootConfig.hpp
@@ -3,6 +3,7 @@
 #include <functional>
 #include <ESP8266WiFi.h>
 #include <ESP8266WebServer.h>
+#include <ESP8266HTTPClient.h>
 #include <DNSServer.h>
 #include <ArduinoJson.h>
 #include "Boot.hpp"
@@ -23,6 +24,7 @@ namespace HomieInternals {
       void setup();
       void loop();
     private:
+      HTTPClient _httpClient;
       ESP8266WebServer _http;
       DNSServer _dns;
       unsigned char _ssidCount;
@@ -32,11 +34,17 @@ namespace HomieInternals {
       char* _jsonWifiNetworks;
       bool _flaggedForReboot;
       unsigned long _flaggedForRebootAt;
+      bool _proxyEnabled;
 
       void _onCaptivePortal();
       void _onDeviceInfoRequest();
       void _onNetworksRequest();
       void _onConfigRequest();
       void _generateNetworksJson();
+      void _onWifiConnectRequest();
+      void _onProxyControlRequest();
+      void _proxyHttpRequest();
+      void _onWifiStatusRequest();
+
   };
 }


### PR DESCRIPTION
@marvinroger, as discussed in #26, I had implemented some apis for enabling more customized captive portals with minor impacts in base Homie firmware. With those apis in place, the developer can use the existing "ui_bundle.gz" capabilities to perform custom interactions with the user and/or cloud services.