### PR TITLE
Proposal for autoregistration of HomieNodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ void setup() {
 
   Homie.setFirmware("awesome-relay", "1.0.0");
   lightNode.subscribe("on", lightOnHandler);
-  Homie.registerNode(lightNode);
   Homie.setup();
 }
 

--- a/docs/2.-Getting-started.md
+++ b/docs/2.-Getting-started.md
@@ -114,7 +114,6 @@ void setup() {
 
   Homie.setFirmware("awesome-relay", "1.0.0");
   lightNode.subscribe("on", lightOnHandler);
-  Homie.registerNode(lightNode);
   Homie.setup();
 }
 
@@ -128,8 +127,7 @@ Alright, step by step:
 1. We create a node with an ID of `light` and a type of `switch` with `HomieNode lightNode("light", "switch")`
 2. We set the name and the version of the firmware with `Homie.setFirmware("awesome-light" ,"1.0.0");`
 3. We want our `light` node to subscribe to the `on` property. We do that with `lightNode.subscribe("on", lightOnHandler);`. The `lightOnHandler` function will be called when the value of this property is changed
-4. We tell Homie for ESP8266 to expose our `light` node by registering it. We do this with `Homie.registerNode(lightNode);`
-5. In the `lightOnHandler` function, we want to update the state of the `light` node. We do this with `Homie.setNodeProperty(lightNode, "on", "true");`
+4. In the `lightOnHandler` function, we want to update the state of the `light` node. We do this with `Homie.setNodeProperty(lightNode, "on", "true");`
 
 In about thirty SLOC, we have achieved to create a smart light, without any hard-coded credentials, with automatic reconnection in case of network failure, and with OTA support. Not bad, right?
 
@@ -168,7 +166,6 @@ void loopHandler() {
 
 void setup() {
   Homie.setFirmware("awesome-temperature", "1.0.0");
-  Homie.registerNode(temperatureNode);
   Homie.setSetupFunction(setupHandler);
   Homie.setLoopFunction(loopHandler);
   Homie.setup();

--- a/docs/7.-API-reference.md
+++ b/docs/7.-API-reference.md
@@ -45,12 +45,6 @@ Set the name and version of the firmware. This is useful for OTA, as Homie will 
 * **`name`**: Name of the firmware. Default value is `undefined`
 * **`version`**: Version of the firmware. Default value is `undefined`
 
-#### void Homie.registerNode (HomieNode `node`)
-
-Register a node.
-
-* **`node`**: node to register
-
 #### void Homie.setGlobalInputHandler (std::function<bool(String nodeId, String property, String value)> `handler`)
 
 Set input handler for subscribed properties.

--- a/examples/DoorSensor/DoorSensor.ino
+++ b/examples/DoorSensor/DoorSensor.ino
@@ -29,7 +29,6 @@ void setup() {
   debouncer.interval(50);
 
   Homie.setFirmware("awesome-door", "1.0.0");
-  Homie.registerNode(doorNode);
   Homie.setLoopFunction(loopHandler);
   Homie.setup();
 }

--- a/examples/IteadSonoff/IteadSonoff.ino
+++ b/examples/IteadSonoff/IteadSonoff.ino
@@ -32,7 +32,6 @@ void setup() {
   Homie.setLedPin(PIN_LED, LOW);
   Homie.setResetTrigger(PIN_BUTTON, LOW, 5000);
   switchNode.subscribe("on", switchOnHandler);
-  Homie.registerNode(switchNode);
   Homie.setup();
 }
 

--- a/examples/LedStrip/LedStrip.ino
+++ b/examples/LedStrip/LedStrip.ino
@@ -44,7 +44,6 @@ void setup() {
   }
 
   Homie.setFirmware("awesome-ledstrip", "1.0.0");
-  Homie.registerNode(stripNode);
   Homie.setup();
 }
 

--- a/examples/LightOnOff/LightOnOff.ino
+++ b/examples/LightOnOff/LightOnOff.ino
@@ -26,7 +26,6 @@ void setup() {
 
   Homie.setFirmware("awesome-relay", "1.0.0");
   lightNode.subscribe("on", lightOnHandler);
-  Homie.registerNode(lightNode);
   Homie.setup();
 }
 

--- a/examples/TemperatureSensor/TemperatureSensor.ino
+++ b/examples/TemperatureSensor/TemperatureSensor.ino
@@ -26,7 +26,6 @@ void loopHandler() {
 
 void setup() {
   Homie.setFirmware("awesome-temperature", "1.0.0");
-  Homie.registerNode(temperatureNode);
   Homie.setSetupFunction(setupHandler);
   Homie.setLoopFunction(loopHandler);
   Homie.setup();

--- a/keywords.txt
+++ b/keywords.txt
@@ -17,7 +17,6 @@ enableBuiltInLedIndicator	KEYWORD2
 setLedPin	KEYWORD2
 setBrand	KEYWORD2
 setFirmware	KEYWORD2
-registerNode	KEYWORD2
 setGlobalInputHandler	KEYWORD2
 setSetupFunction	KEYWORD2
 setLoopFunction	KEYWORD2

--- a/src/Homie.cpp
+++ b/src/Homie.cpp
@@ -127,16 +127,6 @@ void HomieClass::setBrand(const char* name) {
   strcpy(this->_interface.brand, name);
 }
 
-void HomieClass::registerNode(HomieNode& node) {
-  this->_checkBeforeSetup(F("registerNode"));
-  if (this->_interface.registeredNodesCount > MAX_REGISTERED_NODES_COUNT) {
-    Serial.println(F("✖ register(): the max registered nodes count has been reached"));
-    abort();
-  }
-
-  this->_interface.registeredNodes[this->_interface.registeredNodesCount++] = &node;
-}
-
 bool HomieClass::isReadyToOperate() {
   return this->_interface.readyToOperate;
 }

--- a/src/Homie.hpp
+++ b/src/Homie.hpp
@@ -16,6 +16,7 @@
 
 namespace HomieInternals {
   class HomieClass {
+      friend class ::HomieNode;
     public:
       HomieClass();
       ~HomieClass();
@@ -27,7 +28,7 @@ namespace HomieInternals {
       void setLedPin(unsigned char pin, unsigned char on);
       void setBrand(const char* name);
       void setFirmware(const char* name, const char* version);
-      void registerNode(HomieNode& node);
+      void registerNode(HomieNode& node) __attribute__ ((deprecated)) {}
       void setGlobalInputHandler(GlobalInputHandler globalInputHandler);
       void setResettable(bool resettable);
       void onEvent(EventHandler handler);

--- a/src/Homie/Datatypes/Interface.hpp
+++ b/src/Homie/Datatypes/Interface.hpp
@@ -34,9 +34,6 @@ namespace HomieInternals {
       ResetFunction userFunction;
     } reset;
 
-    HomieNode* registeredNodes[MAX_REGISTERED_NODES_COUNT];
-    unsigned char registeredNodesCount;
-
     GlobalInputHandler globalInputHandler;
     OperationFunction setupFunction;
     OperationFunction loopFunction;

--- a/src/Homie/Limits.hpp
+++ b/src/Homie/Limits.hpp
@@ -26,7 +26,6 @@ namespace HomieInternals {
   const unsigned char MAX_NODE_TYPE_LENGTH = sizeof("my-super-awesome-type");
   const unsigned char MAX_NODE_PROPERTY_LENGTH = sizeof("my-super-awesome-property");
 
-  const unsigned char MAX_REGISTERED_NODES_COUNT = 5;
   const unsigned char MAX_SUBSCRIPTIONS_COUNT_PER_NODE = 5;
 
   const unsigned char TOPIC_BUFFER_LENGTH = MAX_MQTT_BASE_TOPIC_LENGTH + MAX_DEVICE_ID_LENGTH + 1 + MAX_NODE_ID_LENGTH + 1 + MAX_NODE_PROPERTY_LENGTH + 4 + 1;

--- a/src/HomieNode.cpp
+++ b/src/HomieNode.cpp
@@ -1,20 +1,30 @@
 #include "HomieNode.hpp"
+#include "Homie.hpp"
 
 using namespace HomieInternals;
+
+HomieNode* HomieNode::_first = 0;
+HomieNode* HomieNode::_last = 0;
+unsigned HomieNode::_nodeCount = 0;
 
 HomieNode::HomieNode(const char* id, const char* type, NodeInputHandler inputHandler, bool subscribeToAll)
 : _id(id)
 , _type(type)
 , _subscriptionsCount(0)
 , _subscribeToAll(subscribeToAll)
-, _inputHandler(inputHandler) {
+, _inputHandler(inputHandler)
+, _next() {
   if (strlen(id) + 1 > MAX_NODE_ID_LENGTH || strlen(type) + 1 > MAX_NODE_TYPE_LENGTH) {
     Serial.println(F("✖ HomieNode(): either the id or type string is too long"));
     abort();
   }
-
-  this->_id = id;
-  this->_type = type;
+  Homie._checkBeforeSetup(F("HomieNode::HomieNode"));
+  if (_last)
+    _last->_next = this;
+  else
+    _first = this;
+  _last = this;
+  ++_nodeCount;
 }
 
 void HomieNode::subscribe(const char* property, PropertyInputHandler inputHandler) {

--- a/src/HomieNode.hpp
+++ b/src/HomieNode.hpp
@@ -20,6 +20,22 @@ class HomieNode {
 
     void subscribe(const char* property, HomieInternals::PropertyInputHandler inputHandler = [](String value) { return false; });
 
+    static void for_each(std::function<void(HomieNode *)> f) {
+      for (HomieNode *n = _first; n; n = n->_next)
+        f(n);
+    }
+
+    static HomieNode *find(String const &id) {
+      for (HomieNode *n = _first; n; n = n->_next)
+        if (id == n->getId())
+          return n;
+      return 0;
+    }
+
+    static unsigned getNodeCount() {
+      return _nodeCount;
+    }
+
   protected:
     virtual void setup() {}
 
@@ -42,4 +58,7 @@ class HomieNode {
     unsigned char _subscriptionsCount;
     bool _subscribeToAll;
     HomieInternals::NodeInputHandler _inputHandler;
+    HomieNode* _next;
+    static HomieNode *_first, *_last;
+    static unsigned _nodeCount;
 };


### PR DESCRIPTION
It removes the array of nodes from Datatypes/Interface.hpp and converts
it to a linked list. First & last pointers are stored as static members
of HomieNode.

Also, it adds 3 static methods to HomieNode: for_each() that executes a
lambda function on every registered node, find() which looks up a node,
and getNodeCount() which returns the number of registered nodes.