### PR TITLE
Add method Homie::publishRaw

### DIFF
--- a/src/Homie.cpp
+++ b/src/Homie.cpp
@@ -211,4 +211,20 @@ bool HomieClass::setNodeProperty(const HomieNode& node, const char* property, co
   return this->_mqttClient.publish(value, retained);
 }
 
+bool HomieClass::publishRaw(const char* topic, const char* value, bool retained) {
+  if (!this->isReadyToOperate()) {
+    this->_logger.logln(F("✖ publishRaw(): impossible now"));
+    return false;
+  }
+  auto topiclen = strlen(topic);
+  if (5 + 2 + topiclen + strlen(value) + 1 > MQTT_MAX_PACKET_SIZE) {
+    this->_logger.logln(F("✖ publishRaw(): content to send is too long"));
+    return false;
+  }
+  auto &cli = this->_mqttClient;
+  auto buf = cli.getTopicBuffer();
+  memcpy(buf, topic, topiclen + 1);
+  return cli.publish(value, retained);
+}
+
 HomieClass Homie;

--- a/src/Homie.hpp
+++ b/src/Homie.hpp
@@ -41,6 +41,10 @@ namespace HomieInternals {
         return this->setNodeProperty(node, property.c_str(), value.c_str(), retained);
       }
       bool setNodeProperty(const HomieNode& node, const char* property, const char* value, bool retained = true);
+      bool publishRaw(const char* topic, const char* value, bool retained = true);
+      inline const char *getBaseTopic() const;
+      inline const char *getId() const;
+
     private:
       bool _setupCalled;
       Boot* _boot;
@@ -55,6 +59,12 @@ namespace HomieInternals {
 
       void _checkBeforeSetup(const __FlashStringHelper* functionName);
   };
+  const char *HomieClass::getId() const {
+    return this->_config.get().deviceId;
+  }
+  const char *HomieClass::getBaseTopic() const {
+    return this->_config.get().mqtt.baseTopic;
+  }
 }
 
 extern HomieInternals::HomieClass Homie;

--- a/src/Homie/Config.cpp
+++ b/src/Homie/Config.cpp
@@ -182,10 +182,6 @@ bool Config::load() {
   return true;
 }
 
-const ConfigStruct& Config::get() {
-  return this->_configStruct;
-}
-
 void Config::erase() {
   if (!this->_spiffsBegin()) { return; }
 

--- a/src/Homie/Config.hpp
+++ b/src/Homie/Config.hpp
@@ -14,7 +14,7 @@ namespace HomieInternals {
       Config();
       void attachInterface(Interface* interface);
       bool load();
-      const ConfigStruct& get();
+      inline const ConfigStruct& get() const;
       void erase();
       void write(const String& config);
       void setOtaMode(bool enabled, const char* version = "");
@@ -31,4 +31,9 @@ namespace HomieInternals {
 
       bool _spiffsBegin();
   };
+
+  const ConfigStruct& Config::get() const {
+    return this->_configStruct;
+  }
+
 }

--- a/src/HomieNode.cpp
+++ b/src/HomieNode.cpp
@@ -38,10 +38,6 @@ bool HomieNode::handleInput(String const &property, String const &value) {
   return this->_inputHandler(property, value);
 }
 
-const char* HomieNode::getId() const {
-  return this->_id;
-}
-
 const char* HomieNode::getType() const {
   return this->_type;
 }

--- a/src/HomieNode.hpp
+++ b/src/HomieNode.hpp
@@ -18,6 +18,8 @@ class HomieNode {
   public:
     HomieNode(const char* id, const char* type, HomieInternals::NodeInputHandler nodeInputHandler = [](String property, String value) { return false; }, bool subscribeToAll = false);
 
+    const char* getId() const { return this->_id; }
+
     void subscribe(const char* property, HomieInternals::PropertyInputHandler inputHandler = [](String value) { return false; });
 
   protected:
@@ -30,7 +32,6 @@ class HomieNode {
     virtual bool handleInput(String const &property, String const &value);
 
   private:
-    const char* getId() const;
     const char* getType() const;
     const HomieInternals::Subscription* getSubscriptions() const;
     unsigned char getSubscriptionsCount() const;


### PR DESCRIPTION
This method allows to publish raw MQTT topics.

It also exposes accessor methods to get the MQTT base topic and the
identifiers of the Homie device and nodes.

This alternative implementation goes away with getNodeTopic(), since it can be implemented using the accessors, which are inline functions which doesn't generate code if unused.