### PR TITLE
Topics/clough42/clear range

### DIFF
--- a/src/Homie.cpp
+++ b/src/Homie.cpp
@@ -22,10 +22,6 @@ SendingPromise& SendingPromise::setRange(HomieRange range) {
   _range = range;
 }
 
-SendingPromise& SendingPromise::clearRange() {
-  _range.isRange = false;
-}
-
 SendingPromise& SendingPromise::setRange(uint16_t rangeIndex) {
   HomieRange range;
   range.isRange = true;

--- a/src/Homie.cpp
+++ b/src/Homie.cpp
@@ -22,6 +22,10 @@ SendingPromise& SendingPromise::setRange(HomieRange range) {
   _range = range;
 }
 
+SendingPromise& SendingPromise::clearRange() {
+  _range.isRange = false;
+}
+
 SendingPromise& SendingPromise::setRange(uint16_t rangeIndex) {
   HomieRange range;
   range.isRange = true;

--- a/src/Homie.hpp
+++ b/src/Homie.hpp
@@ -30,6 +30,7 @@ class SendingPromise {
   SendingPromise& setRetained(bool retained);
   SendingPromise& setRange(HomieRange range);
   SendingPromise& setRange(uint16_t rangeIndex);
+  SendingPromise& clearRange();
   void send(const String& value);
 
  private:
@@ -76,7 +77,7 @@ class HomieClass {
   HomieClass& setStandalone();
 
   SendingPromise& setNodeProperty(const HomieNode& node, const String& property) {
-    return _sendingPromise.setNode(node).setProperty(property).setQos(1).setRetained(true);
+    return _sendingPromise.setNode(node).setProperty(property).setQos(1).setRetained(true).clearRange();
   }
 
   void setIdle(bool idle);

--- a/src/Homie.hpp
+++ b/src/Homie.hpp
@@ -30,7 +30,6 @@ class SendingPromise {
   SendingPromise& setRetained(bool retained);
   SendingPromise& setRange(HomieRange range);
   SendingPromise& setRange(uint16_t rangeIndex);
-  SendingPromise& clearRange();
   void send(const String& value);
 
  private:
@@ -77,7 +76,7 @@ class HomieClass {
   HomieClass& setStandalone();
 
   SendingPromise& setNodeProperty(const HomieNode& node, const String& property) {
-    return _sendingPromise.setNode(node).setProperty(property).setQos(1).setRetained(true).clearRange();
+    return _sendingPromise.setNode(node).setProperty(property).setQos(1).setRetained(true).setRange({ .isRange = false, .index = 0 });
   }
 
   void setIdle(bool idle);


### PR DESCRIPTION
For your consideration:

This change clears the range in HomieClass::setNodeProperty() before returning the SendingPromise to avoid contamination from the previous call.

I chose to add a clearRange() method to SendingPromise to facilitate this because the struct value is inconvenient to initialize for the existing setRange() method.

If you have another suggestion for how to accomplish this, I'll be happy to adjust.

This fixes #149.