### PR TITLE
Bugfix base64-encoded firmware when (size mod 3) equals 1

### DIFF
--- a/src/Homie/Boot/BootNormal.cpp
+++ b/src/Homie/Boot/BootNormal.cpp
@@ -368,7 +368,7 @@ void BootNormal::_onMqttMessage(char* topic, char* payload, AsyncMqttClientMessa
               return;
             }
             // Note the number of pad characters at the end
-            _otaBase64Pads ++;
+            _otaBase64Pads++;
           } else {
             // Non-base64 character in firmware
             _endOtaUpdate(false, UPDATE_ERROR_MAGIC_BYTE);
@@ -419,7 +419,7 @@ void BootNormal::_onMqttMessage(char* topic, char* payload, AsyncMqttClientMessa
           if (index + len == total) {
             // With base64-coded firmware, we may have provided a length off by one or two
             // to Update.begin() because the base64-coded firmware may use padding (one or
-            // two "=") at the end. In case of base64, total length was adjusted above. 
+            // two "=") at the end. In case of base64, total length was adjusted above.
             // Check the real length here and ask Update::end() to skip this test.
             if ((_otaIsBase64) && (_otaSizeDone != _otaSizeTotal)) {
               _endOtaUpdate(false, UPDATE_ERROR_SIZE);

--- a/src/Homie/Boot/BootNormal.hpp
+++ b/src/Homie/Boot/BootNormal.hpp
@@ -45,8 +45,8 @@ class BootNormal : public Boot {
   bool _otaChecksumSet;
   char _otaChecksum[32 + 1];
   bool _otaIsBase64;
-  bool _otaBase64Padded;
   base64_decodestate _otaBase64State;
+  size_t _otaBase64Pads;
   size_t _otaSizeTotal;
   size_t _otaSizeDone;
 


### PR DESCRIPTION
I noticed an issue with base64-encoded OTA updates: for some firmware base-encoded OTA update worked and for some it didn't.

It turned out that, if the real firmware size modulo 3 equaled 1, firmware was incorrectly rejected with `400 BAD_FIRMWARE`. The reason was that the code I added only expected the real firmware size to be off by **one** from the "guestimated" size (3/4 ratio of the total length of the `=` padded base64 payload). However, the real firmware size may as well be off by **two** from the 3/4 ratio.

Examples with some realistic firmware sizes:

Real firmware size | Real size modulo 3 | Base64 length | Base64 Padding | Estimated firmware size | Size off-by
-------------------| ------------------ | ------------- | -------------- | ----------------------- | -----------
346992 | 0 | 462656 | (none) | 346992 | 0
346993 | 1 | 462660 | "==" | 346995 | 2
346994 | 2 | 462660 | "=" | 346995 | 1
346995 | 0 | 462660 | (none) | 346995 | 0
346996 | 1 | 462664 | "==" | 346998 | 2
346997 | 2 | 462664 | "=" | 346998 | 1
346998 | 0 | 462664 | (none) | 346998 | 0

Or, more general (N = any natural number):

Real firmware size | Real size modulo 3 | Base64 length | Base64 Padding | Estimated firmware size | Size off-by
-------------------| ------------------ | ------------- | -------------- | ----------------------- | -----------
N*3 | 0 | N*4 | (none) | N*3 | 0
N*3+1 | 1 | (N+1)*4 | "==" | N*3+1 | 2
N*3+2 | 2 | (N+1)*4 | "=" | N*3+1 | 1

This PR fixes the base64 length issue. In addition, the PR adds a check for payload size evenly dividable by 4 with base64-encoded payloads.