### PR TITLE
Add mac info message on boot normal

### DIFF
--- a/src/Homie/Boot/BootNormal.cpp
+++ b/src/Homie/Boot/BootNormal.cpp
@@ -163,7 +163,7 @@ void BootNormal::_onMqttConnected() {
 
   Interface::get().getMqttClient().publish(_prefixMqttTopic(PSTR("/$homie")), 1, true, HOMIE_VERSION);
   Interface::get().getMqttClient().publish(_prefixMqttTopic(PSTR("/$implementation")), 1, true, "esp8266");
-  Interface::get().getMqttClient().publish(_prefixMqttTopic(PSTR("/$mac")), 1, true, deviceId);
+  Interface::get().getMqttClient().publish(_prefixMqttTopic(PSTR("/$deviceId")), 1, true, deviceId);
 
   for (HomieNode* iNode : HomieNode::nodes) {
     std::unique_ptr<char[]> subtopic = std::unique_ptr<char[]>(new char[1 + strlen(iNode->getId()) + 12 + 1]);  // /id/$properties

--- a/src/Homie/Boot/BootNormal.cpp
+++ b/src/Homie/Boot/BootNormal.cpp
@@ -158,8 +158,12 @@ void BootNormal::_onMqttConnected() {
   _mqttDisconnectNotified = false;
   Interface::get().getLogger() << F("Sending initial information...") << endl;
 
+  const char* deviceId = DeviceId::get();
+  Interface::get().getLogger() << F("Device ID is ") << deviceId << endl;
+
   Interface::get().getMqttClient().publish(_prefixMqttTopic(PSTR("/$homie")), 1, true, HOMIE_VERSION);
   Interface::get().getMqttClient().publish(_prefixMqttTopic(PSTR("/$implementation")), 1, true, "esp8266");
+  Interface::get().getMqttClient().publish(_prefixMqttTopic(PSTR("/$mac")), 1, true, deviceId);
 
   for (HomieNode* iNode : HomieNode::nodes) {
     std::unique_ptr<char[]> subtopic = std::unique_ptr<char[]>(new char[1 + strlen(iNode->getId()) + 12 + 1]);  // /id/$properties


### PR DESCRIPTION
When several devices are used and several are waiting their configuration, it is useful to check the mac address in Homie-ota server. Thanks to this change, the mac appear in inventory of the device in homie-ota server.