### PR TITLE
Clearing config/set topic after applying patch to avoid endless loops when using retained messages

### DIFF
--- a/src/Homie/Boot/BootNormal.cpp
+++ b/src/Homie/Boot/BootNormal.cpp
@@ -500,6 +500,7 @@ void BootNormal::_onMqttMessage(char* topic, char* payload, AsyncMqttClientMessa
 
   // 5. Special Functions set $config
   if (strcmp_P(device_topic, PSTR("$implementation/config/set")) == 0) {
+    Interface::get().getMqttClient().publish(_prefixMqttTopic(PSTR("/$implementation/config/set")), 1, true, "");
     if (Interface::get().getConfig().patch(_mqttPayloadBuffer.get())) {
       Interface::get().getLogger() << F("✔ Configuration updated") << endl;
       _flaggedForReboot = true;


### PR DESCRIPTION
Just got an endless loop when I used a retained message for patching Homie configuration. Clearing the message (publish an "" to the topic) before rebooting will avoid this.