### PR TITLE
Issue 250 fix

### DIFF
--- a/src/Homie/Boot/BootNormal.cpp
+++ b/src/Homie/Boot/BootNormal.cpp
@@ -512,6 +512,13 @@ void BootNormal::_onMqttMessage(char* topic, char* payload, AsyncMqttClientMessa
   }
 
   // 6. Determine specific Node
+  // Determine if message for our deviceid // [Issue #243]
+  const char* messageDeviceId = Interface::get().getConfig().get().deviceId;
+  for (uint16_t i = 0; i < strlen(device_topic); i++) {
+    if ((device_topic[i] != messageDeviceId[i]) || (device_topic[i] == '/' && messageDeviceId[i] != '\0')) {
+      return;
+    }
+  }
 
   // Implicit node properties
   device_topic[strlen(device_topic) - 4] = '\0';  // Remove /set

--- a/src/Homie/Boot/BootNormal.cpp
+++ b/src/Homie/Boot/BootNormal.cpp
@@ -514,8 +514,8 @@ void BootNormal::_onMqttMessage(char* topic, char* payload, AsyncMqttClientMessa
   // 6. Determine specific Node
   // Determine if message for our deviceid // [Issue #243]
   const char* messageDeviceId = Interface::get().getConfig().get().deviceId;
-  for (uint16_t i = 0; i < strlen(device_topic); i++) {
-    if ((device_topic[i] != messageDeviceId[i]) || (device_topic[i] == '/' && messageDeviceId[i] != '\0')) {
+  for (uint16_t i = 0; i < strlen(messageDeviceId); i++) {
+    if ((broadcast_topic[i] != messageDeviceId[i]) || (broadcast_topic[i] == '/' && messageDeviceId[i] != '\0')) {
       return;
     }
   }


### PR DESCRIPTION
@marvinroger Meaculpa, previous commit was completly wrong. This one should fix it.
Please see issue #250 for more details

More generally, with the direct access to MQTT client(getMqttClient()) and so topic arriving could be anything, don't you think "brand/device-id" should be checked each time before processing any topic?
Checking only from device assumes that brand is the same. But those can be different at the content and the length level implying shift in the device-id comparison. And Maybe creating false positive if brand name contain device-id name... 