### PR TITLE
Fixing loopFunction being called too early before MQTT connection is established

### DIFF
--- a/src/Homie/Boot/BootNormal.cpp
+++ b/src/Homie/Boot/BootNormal.cpp
@@ -755,11 +755,11 @@ void BootNormal::loop() {
       Interface::get().getMqttClient().publish(_prefixMqttTopic(PSTR("/$stats/uptime")), 1, true, uptimeStr);
       _statsTimer.tick();
     }
-  }
+  
+    Interface::get().loopFunction();
 
-  Interface::get().loopFunction();
-
-  for (HomieNode* iNode : HomieNode::nodes) {
-    iNode->loop();
+    for (HomieNode* iNode : HomieNode::nodes) {
+      iNode->loop();
+    }
   }
 }


### PR DESCRIPTION
Previously the check was 
` if (!Interface::get().connected) { return; }`

Fixed brackets to ensure loopFunction is only called when homie is connected