### PR TITLE
Fix cpplint failure, causing travis CI to be red

### DIFF
--- a/src/HomieNode.cpp
+++ b/src/HomieNode.cpp
@@ -33,8 +33,7 @@ HomieNode::HomieNode(const char* id, const char* type, NodeInputHandler inputHan
   HomieNode::nodes.push_back(this);
 }
 
-HomieNode::~HomieNode()
-{
+HomieNode::~HomieNode() {
     Interface::get().getLogger() << F("✖ ~HomieNode(): Destruction of HomieNode object not possible") << endl;
     Interface::get().getLogger() << F("  Hint: Don't create HomieNode objects as a local variable (e.g. in setup())") << endl;
     Serial.flush();


### PR DESCRIPTION
E.g. https://travis-ci.org/marvinroger/homie-esp8266/jobs/199213998

Ran the following command successfully:
  cpplint --repository=. --recursive \
  --filter=-whitespace/line_length,-legal/copyright,-runtime/printf,-build/include,-build/namespace,-runtime/int \
  ./src