### PR TITLE
Improve uptime accuracy

### DIFF
--- a/src/Homie/Boot/BootConfig.cpp
+++ b/src/Homie/Boot/BootConfig.cpp
@@ -42,7 +42,7 @@ void BootConfig::setup() {
     WiFi.softAP(apName);
   }
 
-  snprintf(_apIpStr, MAX_IP_STRING_LENGTH, "%d.%d.%d.%d", ACCESS_POINT_IP[0], ACCESS_POINT_IP[1], ACCESS_POINT_IP[2], ACCESS_POINT_IP[3]);
+  snprintf(_apIpStr, MAX_IP_STRING_LENGTH + 1, "%d.%d.%d.%d", ACCESS_POINT_IP[0], ACCESS_POINT_IP[1], ACCESS_POINT_IP[2], ACCESS_POINT_IP[3]);
 
   Interface::get().getLogger() << F("AP started as ") << apName << F(" with IP ") << _apIpStr << endl;
   _dns.setTTL(30);

--- a/src/Homie/Boot/BootConfig.cpp
+++ b/src/Homie/Boot/BootConfig.cpp
@@ -42,7 +42,7 @@ void BootConfig::setup() {
     WiFi.softAP(apName);
   }
 
-  snprintf(_apIpStr, MAX_IP_STRING_LENGTH + 1, "%d.%d.%d.%d", ACCESS_POINT_IP[0], ACCESS_POINT_IP[1], ACCESS_POINT_IP[2], ACCESS_POINT_IP[3]);
+  snprintf(_apIpStr, MAX_IP_STRING_LENGTH, "%d.%d.%d.%d", ACCESS_POINT_IP[0], ACCESS_POINT_IP[1], ACCESS_POINT_IP[2], ACCESS_POINT_IP[3]);
 
   Interface::get().getLogger() << F("AP started as ") << apName << F(" with IP ") << _apIpStr << endl;
   _dns.setTTL(30);

--- a/src/Homie/Boot/BootNormal.cpp
+++ b/src/Homie/Boot/BootNormal.cpp
@@ -190,7 +190,7 @@ void BootNormal::_onMqttConnected() {
 
   IPAddress localIp = WiFi.localIP();
   char localIpStr[MAX_IP_STRING_LENGTH];
-  snprintf(localIpStr, MAX_IP_STRING_LENGTH - 1, "%d.%d.%d.%d", localIp[0], localIp[1], localIp[2], localIp[3]);
+  snprintf(localIpStr, MAX_IP_STRING_LENGTH + 1, "%d.%d.%d.%d", localIp[0], localIp[1], localIp[2], localIp[3]);
 
   Interface::get().getMqttClient().publish(_prefixMqttTopic(PSTR("/$localip")), 1, true, localIpStr);
 

--- a/src/Homie/Boot/BootNormal.cpp
+++ b/src/Homie/Boot/BootNormal.cpp
@@ -662,7 +662,7 @@ void BootNormal::setup() {
   Interface::get().getMqttClient().onPublish(std::bind(&BootNormal::_onMqttPublish, this, std::placeholders::_1));
 
   Interface::get().getMqttClient().setServer(Interface::get().getConfig().get().mqtt.server.host, Interface::get().getConfig().get().mqtt.server.port);
-  Interface::get().getMqttClient().setKeepAlive(10).setMaxTopicLength(MAX_MQTT_TOPIC_LENGTH);
+  Interface::get().getMqttClient().setMaxTopicLength(MAX_MQTT_TOPIC_LENGTH);
   _mqttClientId = std::unique_ptr<char[]>(new char[strlen(Interface::get().brand) + 1 + strlen(Interface::get().getConfig().get().deviceId) + 1]);
   strcpy(_mqttClientId.get(), Interface::get().brand);
   strcat_P(_mqttClientId.get(), PSTR("-"));

--- a/src/Homie/Uptime.cpp
+++ b/src/Homie/Uptime.cpp
@@ -3,16 +3,16 @@
 using namespace HomieInternals;
 
 Uptime::Uptime()
-: _seconds(0)
+: _milliseconds(0)
 , _lastTick(0) {
 }
 
 void Uptime::update() {
   uint32_t now = millis();
-  _seconds += (now - _lastTick) / 1000UL;
+  _milliseconds += (now - _lastTick);
   _lastTick = now;
 }
 
 uint64_t Uptime::getSeconds() const {
-  return _seconds;
+  return (_milliseconds / 1000ULL);
 }

--- a/src/Homie/Uptime.hpp
+++ b/src/Homie/Uptime.hpp
@@ -10,7 +10,7 @@ class Uptime {
   uint64_t getSeconds() const;
 
  private:
-  uint64_t _seconds;
+  uint64_t _milliseconds;
   uint32_t _lastTick;
 };
 }  // namespace HomieInternals

--- a/src/Homie/Utils/DeviceId.cpp
+++ b/src/Homie/Utils/DeviceId.cpp
@@ -7,7 +7,7 @@ char DeviceId::_deviceId[];  // need to define the static variable
 void DeviceId::generate() {
   uint8_t mac[6];
   WiFi.macAddress(mac);
-  snprintf(DeviceId::_deviceId, MAX_MAC_STRING_LENGTH+1 , "%02x%02x%02x%02x%02x%02x", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+  snprintf(DeviceId::_deviceId, MAX_MAC_STRING_LENGTH + 1 , "%02x%02x%02x%02x%02x%02x", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
 }
 
 const char* DeviceId::get() {


### PR DESCRIPTION
Improve accuracy of the uptime calculation by storing uptime as milliseconds.
Conversion to seconds is only done when preparing to main code.

Drawback: the maximum uptime is a lot lower than before, but still way more than I'd ever live.