### PR TITLE
Fix #301 remove hardcoded keepalive

### DIFF
--- a/src/Homie/Boot/BootNormal.cpp
+++ b/src/Homie/Boot/BootNormal.cpp
@@ -662,7 +662,7 @@ void BootNormal::setup() {
   Interface::get().getMqttClient().onPublish(std::bind(&BootNormal::_onMqttPublish, this, std::placeholders::_1));
 
   Interface::get().getMqttClient().setServer(Interface::get().getConfig().get().mqtt.server.host, Interface::get().getConfig().get().mqtt.server.port);
-  Interface::get().getMqttClient().setKeepAlive(10).setMaxTopicLength(MAX_MQTT_TOPIC_LENGTH);
+  Interface::get().getMqttClient().setMaxTopicLength(MAX_MQTT_TOPIC_LENGTH);
   _mqttClientId = std::unique_ptr<char[]>(new char[strlen(Interface::get().brand) + 1 + strlen(Interface::get().getConfig().get().deviceId) + 1]);
   strcpy(_mqttClientId.get(), Interface::get().brand);
   strcat_P(_mqttClientId.get(), PSTR("-"));


### PR DESCRIPTION
Fix for #301: Remove hardcoded KeepAlive for MQTT connection.
Default value of 15sec is already present in AsyncMQTT library.

Custom keepalive value got overwritten by the hardcoded one, but Homie would ping based on the custom setting.