### PR TITLE
Improve uptime accuracy

### DIFF
--- a/src/Homie/Uptime.cpp
+++ b/src/Homie/Uptime.cpp
@@ -3,16 +3,16 @@
 using namespace HomieInternals;
 
 Uptime::Uptime()
-: _seconds(0)
+: _milliseconds(0)
 , _lastTick(0) {
 }
 
 void Uptime::update() {
   uint32_t now = millis();
-  _seconds += (now - _lastTick) / 1000UL;
+  _milliseconds += (now - _lastTick);
   _lastTick = now;
 }
 
 uint64_t Uptime::getSeconds() const {
-  return _seconds;
+  return (_milliseconds / 1000ULL);
 }

--- a/src/Homie/Uptime.hpp
+++ b/src/Homie/Uptime.hpp
@@ -10,7 +10,7 @@ class Uptime {
   uint64_t getSeconds() const;
 
  private:
-  uint64_t _seconds;
+  uint64_t _milliseconds;
   uint32_t _lastTick;
 };
 }  // namespace HomieInternals


### PR DESCRIPTION
improve uptime accuracy by storing milliseconds and only rounding when publishing value
drawback: less time before rollover uptime, but still long enough