### PR TITLE
Support for static IP and BSSID/MAC, Channel of AP

### DIFF
--- a/src/Homie/Boot/BootNormal.hpp
+++ b/src/Homie/Boot/BootNormal.hpp
@@ -68,5 +68,6 @@ class BootNormal : public Boot {
   uint16_t _publishOtaStatus(int status, const char* info = nullptr);
   uint16_t _publishOtaStatus_P(int status, PGM_P info);
   void _endOtaUpdate(bool success, uint8_t update_error = UPDATE_ERROR_OK);
+  void _stringToBytes(const char* str, char sep, byte* bytes, int maxBytes, int base);
 };
 }  // namespace HomieInternals

--- a/src/Homie/Config.cpp
+++ b/src/Homie/Config.cpp
@@ -67,6 +67,36 @@ bool Config::load() {
   if (parsedJson.containsKey("device_id")) {
     reqDeviceId = parsedJson["device_id"];
   }
+
+  const char* reqWifiBssid = "";
+  if (parsedJson["wifi"].as<JsonObject&>().containsKey("bssid")) {
+    reqWifiBssid = parsedJson["wifi"]["bssid"];
+  }
+  uint16_t reqWifiChannel = 0;
+  if (parsedJson["wifi"].as<JsonObject&>().containsKey("channel")) {
+    reqWifiChannel = parsedJson["wifi"]["channel"];
+  }
+  const char* reqWifiIp = "";
+  if (parsedJson["wifi"].as<JsonObject&>().containsKey("ip")) {
+    reqWifiIp = parsedJson["wifi"]["ip"];
+  }
+  const char* reqWifiMask = "";
+  if (parsedJson["wifi"].as<JsonObject&>().containsKey("mask")) {
+    reqWifiMask = parsedJson["wifi"]["mask"];
+  }
+  const char* reqWifiGw = "";
+  if (parsedJson["wifi"].as<JsonObject&>().containsKey("gw")) {
+    reqWifiGw = parsedJson["wifi"]["gw"];
+  }
+  const char* reqWifiDns1 = "";
+  if (parsedJson["wifi"].as<JsonObject&>().containsKey("dns1")) {
+    reqWifiDns1 = parsedJson["wifi"]["dns1"];
+  }
+  const char* reqWifiDns2 = "";
+  if (parsedJson["wifi"].as<JsonObject&>().containsKey("dns2")) {
+    reqWifiDns2 = parsedJson["wifi"]["dns2"];
+  }
+
   uint16_t reqMqttPort = DEFAULT_MQTT_PORT;
   if (parsedJson["mqtt"].as<JsonObject&>().containsKey("port")) {
     reqMqttPort = parsedJson["mqtt"]["port"];
@@ -94,9 +124,16 @@ bool Config::load() {
   }
 
   strlcpy(_configStruct.name, reqName, MAX_FRIENDLY_NAME_LENGTH);
+  strlcpy(_configStruct.deviceId, reqDeviceId, MAX_DEVICE_ID_LENGTH);
   strlcpy(_configStruct.wifi.ssid, reqWifiSsid, MAX_WIFI_SSID_LENGTH);
   if (reqWifiPassword) strlcpy(_configStruct.wifi.password, reqWifiPassword, MAX_WIFI_PASSWORD_LENGTH);
-  strlcpy(_configStruct.deviceId, reqDeviceId, MAX_DEVICE_ID_LENGTH);
+  strlcpy(_configStruct.wifi.bssid, reqWifiBssid, MAX_MAC_STRING_LENGTH + 6);
+  _configStruct.wifi.channel = reqWifiChannel;
+  strlcpy(_configStruct.wifi.ip, reqWifiIp, MAX_IP_STRING_LENGTH);
+  strlcpy(_configStruct.wifi.gw, reqWifiGw, MAX_IP_STRING_LENGTH);
+  strlcpy(_configStruct.wifi.mask, reqWifiMask, MAX_IP_STRING_LENGTH);
+  strlcpy(_configStruct.wifi.dns1, reqWifiDns1, MAX_IP_STRING_LENGTH);
+  strlcpy(_configStruct.wifi.dns2, reqWifiDns2, MAX_IP_STRING_LENGTH);
   strlcpy(_configStruct.mqtt.server.host, reqMqttHost, MAX_HOSTNAME_LENGTH);
   _configStruct.mqtt.server.port = reqMqttPort;
   strlcpy(_configStruct.mqtt.baseTopic, reqMqttBaseTopic, MAX_MQTT_BASE_TOPIC_LENGTH);
@@ -286,7 +323,11 @@ void Config::log() const {
   Interface::get().getLogger() << F("  • Wi-Fi: ") << endl;
   Interface::get().getLogger() << F("    ◦ SSID: ") << _configStruct.wifi.ssid << endl;
   Interface::get().getLogger() << F("    ◦ Password not shown") << endl;
-
+  if (strcmp_P(_configStruct.wifi.ip, PSTR("")) != 0) {
+    Interface::get().getLogger() << F("    ◦ IP: ") << _configStruct.wifi.ip << endl;
+    Interface::get().getLogger() << F("    ◦ Mask: ") << _configStruct.wifi.mask << endl;
+    Interface::get().getLogger() << F("    ◦ Gateway: ") << _configStruct.wifi.gw << endl;
+  }
   Interface::get().getLogger() << F("  • MQTT: ") << endl;
   Interface::get().getLogger() << F("    ◦ Host: ") << _configStruct.mqtt.server.host << endl;
   Interface::get().getLogger() << F("    ◦ Port: ") << _configStruct.mqtt.server.port << endl;

--- a/src/Homie/Datatypes/ConfigStruct.hpp
+++ b/src/Homie/Datatypes/ConfigStruct.hpp
@@ -11,6 +11,13 @@ struct ConfigStruct {
   struct WiFi {
     char ssid[MAX_WIFI_SSID_LENGTH];
     char password[MAX_WIFI_PASSWORD_LENGTH];
+    char bssid[MAX_MAC_STRING_LENGTH + 6];
+    uint16_t channel;
+    char ip[MAX_IP_STRING_LENGTH];
+    char mask[MAX_IP_STRING_LENGTH];
+    char gw[MAX_IP_STRING_LENGTH];
+    char dns1[MAX_IP_STRING_LENGTH];
+    char dns2[MAX_IP_STRING_LENGTH];
   } wifi;
 
   struct MQTT {

--- a/src/Homie/Limits.hpp
+++ b/src/Homie/Limits.hpp
@@ -4,7 +4,8 @@
 
 namespace HomieInternals {
   const uint16_t MAX_JSON_CONFIG_FILE_SIZE = 1000;
-  const uint16_t MAX_JSON_CONFIG_ARDUINOJSON_BUFFER_SIZE = JSON_OBJECT_SIZE(6) + JSON_OBJECT_SIZE(2) + JSON_OBJECT_SIZE(6) + JSON_OBJECT_SIZE(1) + JSON_OBJECT_SIZE(10);  // Max 5 elements at root, 2 elements in nested, etc... the last 10 means 10 custom settings max
+  // 6 elements at root, 9 elements at wifi, 6 elements at mqtt, 1 element at ota, max 10 elements at settings
+  const uint16_t MAX_JSON_CONFIG_ARDUINOJSON_BUFFER_SIZE = JSON_OBJECT_SIZE(6) + JSON_OBJECT_SIZE(9) + JSON_OBJECT_SIZE(6) + JSON_OBJECT_SIZE(1) + JSON_OBJECT_SIZE(10);
 
   const uint8_t MAX_WIFI_SSID_LENGTH = 32 + 1;
   const uint8_t MAX_WIFI_PASSWORD_LENGTH = 64 + 1;

--- a/src/Homie/Utils/Helpers.cpp
+++ b/src/Homie/Utils/Helpers.cpp
@@ -15,6 +15,39 @@ uint8_t Helpers::rssiToPercentage(int32_t rssi) {
   return quality;
 }
 
+void Helpers::stringToBytes(const char* str, char sep, byte* bytes, int maxBytes, int base) {
+  //taken from http://stackoverflow.com/a/35236734
+  for (int i = 0; i < maxBytes; i++) {
+    bytes[i] = strtoul(str, NULL, base);
+    str = strchr(str, sep);
+    if (str == NULL || *str == '\0') {
+      break;
+    }
+    str++;
+  }
+}
+
+bool Helpers::validateMacAddress(const char *mac) {
+  //taken from http://stackoverflow.com/a/4792211
+  int i = 0;
+  int s = 0;
+  while (*mac) {
+    if (isxdigit(*mac)) {
+      i++;
+    }
+    else if (*mac == ':' || *mac == '-') {
+      if (i == 0 || i / 2 - 1 != s)
+        break;
+      ++s;
+    }
+    else {
+       s = -1;
+    }
+    ++mac;
+  }
+  return (i == MAX_MAC_STRING_LENGTH && s == 5);
+}
+
 std::unique_ptr<char[]> Helpers::cloneString(const String& string) {
   size_t length = string.length();
   std::unique_ptr<char[]> copy(new char[length + 1]);

--- a/src/Homie/Utils/Helpers.hpp
+++ b/src/Homie/Utils/Helpers.hpp
@@ -1,13 +1,15 @@
 #pragma once
 
 #include "Arduino.h"
-
+#include "../Limits.hpp"
 #include <memory>
 
 namespace HomieInternals {
 class Helpers {
  public:
   static uint8_t rssiToPercentage(int32_t rssi);
+  static void stringToBytes(const char* str, char sep, byte* bytes, int maxBytes, int base);
+  static bool validateMacAddress(const char* mac);
   static std::unique_ptr<char[]> cloneString(const String& string);
 };
 }  // namespace HomieInternals

--- a/src/Homie/Utils/Validation.cpp
+++ b/src/Homie/Utils/Validation.cpp
@@ -76,6 +76,95 @@ ConfigValidationResult Validation::_validateConfigWifi(const JsonObject& object)
     result.reason = F("wifi.password is too long");
     return result;
   }
+  // by benzino
+  if (object["wifi"].as<JsonObject&>().containsKey("bssid") && !object["wifi"]["bssid"].is<const char*>()) {
+    result.reason = F("wifi.bssid is not a string");
+    return result;
+  }
+  if ( (object["wifi"].as<JsonObject&>().containsKey("bssid") && !object["wifi"].as<JsonObject&>().containsKey("channel")) ||
+       (!object["wifi"].as<JsonObject&>().containsKey("bssid") && object["wifi"].as<JsonObject&>().containsKey("channel")) ) {
+    result.reason = F("wifi.channel_bssid channel and BSSID is required");
+    return result;
+  }
+  if (object["wifi"].as<JsonObject&>().containsKey("bssid") && !Helpers::validateMacAddress(object["wifi"].as<JsonObject&>().get<const char*>("bssid"))) {
+    result.reason = F("wifi.bssid is not valid mac");
+    return result;
+  }
+  if (object["wifi"].as<JsonObject&>().containsKey("channel") && !object["wifi"]["channel"].is<uint16_t>()) {
+    result.reason = F("wifi.channel is not an integer");
+    return result;
+  }
+  IPAddress ipAddress;
+  if (object["wifi"].as<JsonObject&>().containsKey("ip") && !object["wifi"]["ip"].is<const char*>()) {
+    result.reason = F("wifi.ip is not a string");
+    return result;
+  }
+  if (object["wifi"]["ip"] && strlen(object["wifi"]["ip"]) + 1 > MAX_IP_STRING_LENGTH) {
+    result.reason = F("wifi.ip is too long");
+    return result;
+  }
+  if (object["wifi"]["ip"] && !ipAddress.fromString(object["wifi"].as<JsonObject&>().get<const char*>("ip"))) {
+    result.reason = F("wifi.ip is not valid ip address");
+    return result;
+  }
+  if (object["wifi"].as<JsonObject&>().containsKey("mask") && !object["wifi"]["mask"].is<const char*>()) {
+    result.reason = F("wifi.mask is not a string");
+    return result;
+  }
+  if (object["wifi"]["mask"] && strlen(object["wifi"]["mask"]) + 1 > MAX_IP_STRING_LENGTH) {
+    result.reason = F("wifi.mask is too long");
+    return result;
+  }
+  if (object["wifi"]["mask"] && !ipAddress.fromString(object["wifi"].as<JsonObject&>().get<const char*>("mask"))) {
+    result.reason = F("wifi.mask is not valid mask");
+    return result;
+  }
+  if (object["wifi"].as<JsonObject&>().containsKey("gw") && !object["wifi"]["gw"].is<const char*>()) {
+    result.reason = F("wifi.gw is not a string");
+    return result;
+  }
+  if (object["wifi"]["gw"] && strlen(object["wifi"]["gw"]) + 1 > MAX_IP_STRING_LENGTH) {
+    result.reason = F("wifi.gw is too long");
+    return result;
+  }
+  if (object["wifi"]["gw"] && !ipAddress.fromString(object["wifi"].as<JsonObject&>().get<const char*>("gw"))) {
+    result.reason = F("wifi.gw is not valid gateway address");
+    return result;
+  }
+  if ( (object["wifi"].as<JsonObject&>().containsKey("ip") && (!object["wifi"].as<JsonObject&>().containsKey("mask") || !object["wifi"].as<JsonObject&>().containsKey("gw"))) ||
+    (object["wifi"].as<JsonObject&>().containsKey("gw") && (!object["wifi"].as<JsonObject&>().containsKey("mask") || !object["wifi"].as<JsonObject&>().containsKey("ip"))) ||
+    (object["wifi"].as<JsonObject&>().containsKey("mask") && (!object["wifi"].as<JsonObject&>().containsKey("ip") || !object["wifi"].as<JsonObject&>().containsKey("gw")))) {
+    result.reason = F("wifi.staticip ip, gw and mask is required");
+    return result;
+  }
+  if (object["wifi"].as<JsonObject&>().containsKey("dns1") && !object["wifi"]["dns1"].is<const char*>()) {
+    result.reason = F("wifi.dns1 is not a string");
+    return result;
+  }
+  if (object["wifi"]["dns1"] && strlen(object["wifi"]["dns1"]) + 1 > MAX_IP_STRING_LENGTH) {
+    result.reason = F("wifi.dns1 is too long");
+    return result;
+  }
+  if (object["wifi"]["dns1"] && !ipAddress.fromString(object["wifi"].as<JsonObject&>().get<const char*>("dns1"))) {
+    result.reason = F("wifi.dns1 is not valid dns address");
+    return result;
+  }
+  if (object["wifi"].as<JsonObject&>().containsKey("dns2") && !object["wifi"].as<JsonObject&>().containsKey("dns1")) {
+    result.reason = F("wifi.dns2 no dns1 defined");
+    return result;
+  }
+  if (object["wifi"].as<JsonObject&>().containsKey("dns2") && !object["wifi"]["dns2"].is<const char*>()) {
+    result.reason = F("wifi.dns2 is not a string");
+    return result;
+  }
+  if (object["wifi"]["dns2"] && strlen(object["wifi"]["dns2"]) + 1 > MAX_IP_STRING_LENGTH) {
+    result.reason = F("wifi.dns2 is too long");
+    return result;
+  }
+  if (object["wifi"]["dns2"] && !ipAddress.fromString(object["wifi"].as<JsonObject&>().get<const char*>("dns2"))) {
+    result.reason = F("wifi.dns2 is not valid dns address");
+    return result;
+  }
 
   const char* wifiSsid = object["wifi"]["ssid"];
   if (strcmp_P(wifiSsid, PSTR("")) == 0) {
@@ -262,3 +351,23 @@ ConfigValidationResult Validation::_validateConfigSettings(const JsonObject& obj
   result.valid = true;
   return result;
 }
+
+// bool Validation::_validateConfigWifiBssid(const char *mac) {
+//   int i = 0;
+//   int s = 0;
+//   while (*mac) {
+//    if (isxdigit(*mac)) {
+//       i++;
+//    }
+//    else if (*mac == ':' || *mac == '-') {
+//       if (i == 0 || i / 2 - 1 != s)
+//         break;
+//       ++s;
+//    }
+//    else {
+//        s = -1;
+//    }
+//    ++mac;
+//   }
+//   return (i == MAX_MAC_STRING_LENGTH && s == 5);
+// }

--- a/src/Homie/Utils/Validation.hpp
+++ b/src/Homie/Utils/Validation.hpp
@@ -3,6 +3,8 @@
 #include "Arduino.h"
 
 #include <ArduinoJson.h>
+#include <IPAddress.h>
+#include "Helpers.hpp"
 #include "../Limits.hpp"
 #include "../../HomieSetting.hpp"
 
@@ -22,5 +24,6 @@ class Validation {
   static ConfigValidationResult _validateConfigMqtt(const JsonObject& object);
   static ConfigValidationResult _validateConfigOta(const JsonObject& object);
   static ConfigValidationResult _validateConfigSettings(const JsonObject& object);
+  //static bool _validateConfigWifiBssid(const char* mac);
 };
 }  // namespace HomieInternals


### PR DESCRIPTION
- added parameters to config.json which allow to define static ip, mask,
gateway, dns
- added parameters to config.json which allow to define BSSID and
channel of AP

To run device with defined static IP you have to define ip, mask and
gateway together.

To point device to connect to specific BSSID and channel you haveto
define bssid and channel together.

```
{

	"name": "The kitchen light",
	"device_id": "kitchen-light",
	"wifi": {
		"ssid": "Network_1",
		"password": "I'm a Wi-Fi password!",
		"bssid": "DE:AD:BE:EF:BA:BE",
		"channel": 1,
		"ip": "192.168.1.5",
		"mask": "255.255.255.0",
		"gw": "192.168.1.1"
	},
	"mqtt": {
		"host": "192.168.1.10",
		"port": 1883,
		"base_topic": "devices/",
		"auth": true,
		"username": "user",
		"password": "pass" i
	},
	"ota": {
		"enabled": true
	},
	"settings": {
		"param1": 55,
		"param2": "abcdefghijklm",
		"param3": true,
		"param4": false,
		"param5": 2147483647,
		"param6": -2147483647,
		"param7": 55,
		"param8": "abcdefghijklm",
		"param9": true,
		"param10": false
	}
}
```