### PR TITLE
 IHomieSetting::settings first, HomieNode-settings second!

### DIFF
--- a/src/HomieSetting.cpp
+++ b/src/HomieSetting.cpp
@@ -2,7 +2,7 @@
 
 using namespace HomieInternals;
 
-std::vector<IHomieSetting*>  __attribute__ ((init_priority (101))) IHomieSetting::settings;
+std::vector<IHomieSetting*> __attribute__((init_priority (101))) IHomieSetting::settings;
 
 template <class T>
 HomieSetting<T>::HomieSetting(const char* name, const char* description)

--- a/src/HomieSetting.cpp
+++ b/src/HomieSetting.cpp
@@ -2,7 +2,7 @@
 
 using namespace HomieInternals;
 
-std::vector<IHomieSetting*> IHomieSetting::settings;
+std::vector<IHomieSetting*>  __attribute__ ((init_priority (101))) IHomieSetting::settings;
 
 template <class T>
 HomieSetting<T>::HomieSetting(const char* name, const char* description)

--- a/src/HomieSetting.cpp
+++ b/src/HomieSetting.cpp
@@ -2,7 +2,7 @@
 
 using namespace HomieInternals;
 
-std::vector<IHomieSetting*> __attribute__((init_priority (101))) IHomieSetting::settings;
+std::vector<IHomieSetting*> __attribute__((init_priority(101))) IHomieSetting::settings;
 
 template <class T>
 HomieSetting<T>::HomieSetting(const char* name, const char* description)


### PR DESCRIPTION
Set initialization priority of IHomieSetting::settings to value of highest allowed priority (101).

This allows other static variables to be of type HomieSetting< T>.

See https://github.com/euphi/HomieNodeCollection/blob/master/src/RGBWNode.cpp for example.

Note: It makes sense to have a static HomieSetting member, if you have a class that may be instantiated multiple times. (e.g. two LED Strips connected to the same ESP8266, as shown in https://github.com/euphi/ESP-LEDCtrl).