### PR TITLE
Breakup load into separate functions

### DIFF
--- a/src/Homie/Config.hpp
+++ b/src/Homie/Config.hpp
@@ -18,6 +18,7 @@ namespace HomieInternals {
 class Config {
  public:
   Config();
+  JsonObject& loadJSONObject();
   bool load();
   inline const ConfigStruct& get() const;
   char* getSafeConfigFile() const;


### PR DESCRIPTION
This splits off the actual loading of the JSON file and parsing into a new function. The idea is that eventually I'd like to make modifying the configuration file available to the code base.

I'm not sure what the best method for exposing the configuration is, but this is a start.