### PR TITLE
Fix: not returning a value in a method that returns non-void

### DIFF
--- a/src/Homie.cpp
+++ b/src/Homie.cpp
@@ -196,6 +196,7 @@ HomieClass& HomieClass::setConfigurationApPassword(const char* password) {
 
   Interface::get().configurationAp.secured = true;
   strlcpy(Interface::get().configurationAp.password, password, MAX_WIFI_PASSWORD_LENGTH);
+  return *this;
 }
 
 void HomieClass::__setFirmware(const char* name, const char* version) {


### PR DESCRIPTION
`HomieClass& HomieClass::setConfigurationApPassword(const char* password)` did not returned a reference to the Homie instance. This PR fixes this.