### PR TITLE
Prevent Wifi reconnect before reboot

### DIFF
--- a/src/Homie/Boot/BootConfig.cpp
+++ b/src/Homie/Boot/BootConfig.cpp
@@ -385,6 +385,7 @@ void BootConfig::loop() {
   if (_flaggedForReboot) {
     if (millis() - _flaggedForRebootAt >= 3000UL) {
       Interface::get().getLogger() << F("↻ Rebooting into normal mode...") << endl;
+      Interface::get().flaggedForSleep = true;
       Serial.flush();
       ESP.restart();
     }

--- a/src/Homie/Boot/BootNormal.cpp
+++ b/src/Homie/Boot/BootNormal.cpp
@@ -816,6 +816,7 @@ void BootNormal::loop() {
     Interface::get().eventHandler(Interface::get().event);
 
     Interface::get().getLogger() << F("↻ Rebooting into config mode...") << endl;
+    Interface::get().flaggedForSleep = true;
     Serial.flush();
     ESP.restart();
   }
@@ -824,6 +825,7 @@ void BootNormal::loop() {
     Interface::get().getLogger() << F("Device is idle") << endl;
 
     Interface::get().getLogger() << F("↻ Rebooting...") << endl;
+    Interface::get().flaggedForSleep = true;
     Serial.flush();
     ESP.restart();
   }

--- a/src/Homie/Boot/BootStandalone.cpp
+++ b/src/Homie/Boot/BootStandalone.cpp
@@ -53,6 +53,7 @@ void BootStandalone::loop() {
     Interface::get().eventHandler(Interface::get().event);
 
     Interface::get().getLogger() << F("↻ Rebooting into config mode...") << endl;
+    Interface::get().flaggedForSleep = true;
     Serial.flush();
     ESP.restart();
   }


### PR DESCRIPTION
When Homie schedules a reboot, it disconnects Wifi, but tries to reconnect afterwards, which results in a crash. 

This seems to happen because `ESP.restart()` - contrary to what one would expect - returns and leaves the program running for a short while, before actually restarting the processor. 

This patch disables the interface, so that it won't reconnect anymore after the reboot has been requested. A different way to achieve the same result may be a `while(1);` after `ESP.restart()`.