### PR TITLE
Fix Safari not displaying the config bundle HTML page

### DIFF
--- a/src/Homie/Boot/BootConfig.cpp
+++ b/src/Homie/Boot/BootConfig.cpp
@@ -260,7 +260,7 @@ void BootConfig::_onCaptivePortal(AsyncWebServerRequest *request) {
   } else if (request->url() == "/" && SPIFFS.exists(CONFIG_UI_BUNDLE_PATH)) {
     // Respond with UI
     Interface::get().getLogger() << F("UI bundle found") << endl;
-    AsyncWebServerResponse *response = request->beginResponse(SPIFFS, CONFIG_UI_BUNDLE_PATH, F("text/html"));
+    AsyncWebServerResponse *response = request->beginResponse(SPIFFS.open(CONFIG_UI_BUNDLE_PATH, "r"), F("index.html"), F("text/html"));
     response->addHeader("Content-Encoding", "gzip");
     request->send(response);
   } else {


### PR DESCRIPTION
Safari cannot deal with gzip files that have a "*.gz" file extension.
Simply faking the filename solves the problem though.

Fixes #476