### PR TITLE
Require use of PIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Add the `PIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY` build flag to ensure reliable O
 platform = ...
 board = ...
 framework = arduino
+build_flags = -D PIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY
 
 ; the latest development branch
 lib_deps = https://github.com/marvinroger/homie-esp8266.git

--- a/README.md
+++ b/README.md
@@ -33,8 +33,11 @@ The Git repository contains the development version of Homie for ESP8266. Stable
 platform = espressif8266
 board = ...
 framework = arduino
+build_flags = -D PIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY
 lib_deps = Homie
 ```
+
+Add the `PIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY` build flag to ensure reliable OTA updates.
 
 ### Development version
 


### PR DESCRIPTION
A small documentation update so users set the `PIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY` build flag for reliable OTA updates.