### PR TITLE
Avoid memory clogging when WiFi disconnected

### DIFF
--- a/src/Homie/Boot/BootNormal.cpp
+++ b/src/Homie/Boot/BootNormal.cpp
@@ -387,12 +387,16 @@ void BootNormal::_onWifiDisconnected(const WiFiEventStationModeDisconnected& eve
   Interface::get().event.wifiReason = event.reason;
   Interface::get().eventHandler(Interface::get().event);
 
-  _wifiConnect();
+  //_wifiConnect();
 }
 #endif // ESP32
 
 void BootNormal::_mqttConnect() {
-  if (!Interface::get().disable) {
+  bool fence=!Interface::get().disable;;
+  #if defined(ESP8266)
+    fence &= WiFi.isConnected();
+  #endif // ESP32
+  if (fence) {
     if (Interface::get().led.enabled) Interface::get().getBlinker().start(LED_MQTT_DELAY);
     _mqttConnectNotified = false;
     Interface::get().getLogger() << F("↕ Attempting to connect to MQTT...") << endl;

--- a/src/Homie/Boot/BootNormal.cpp
+++ b/src/Homie/Boot/BootNormal.cpp
@@ -392,7 +392,7 @@ void BootNormal::_onWifiDisconnected(const WiFiEventStationModeDisconnected& eve
 #endif // ESP32
 
 void BootNormal::_mqttConnect() {
-  bool fence=!Interface::get().disable;;
+  bool fence = !Interface::get().disable;;
   #if defined(ESP8266)
     fence &= WiFi.isConnected();
   #endif // ESP32


### PR DESCRIPTION
395ff
The continous MQTT reconnect attempts - when the WiFi is disconnected - always eat up some memory from the heap.
If the WiFI is off for some hours, no memory is left and I get a 
`Exception 29: StoreProhibited: A store referenced a page mapped with an attribute that does not permit stores`
when the WiFi is reconnecting and the device reboots.
I noticed this, since I have the outputs of my ESP8266 control luminaries and they turn on or off hazardously after the WiFi and MQTT reconnects.  Some outputs are shared pins with builtin LEDs, but of course the `Homie.disableLedFeedback();` does not survive the reboot.
The code only attempts to reconnect the MQTT if the WiFi is connected.  This way, the memory is not eaten up while the station is offline.
Could not test with ESP32 if this needs to / can be done there as well since I do not have one.   If it does work as well, the code could be simplified taking out the precompiler directives.
390:
since for ESP8266 we have set `WiFi.setAutoConnect(true)` and `WiFi.setAutoReconnect()` , it is in my opinion not necessary to explicitly call `_wifiConnect();`   The WIFI_DISCONNECTED event is fired constantly, anyway (every 3 seconds or so).
This however, does not lead to memory clogging.
