### PR TITLE
fix for issue #716 #711

### DIFF
--- a/src/Homie/Boot/BootConfig.cpp
+++ b/src/Homie/Boot/BootConfig.cpp
@@ -312,7 +312,7 @@ void BootConfig::_proxyHttpRequest(AsyncWebServerRequest *request) {
 
   // send request to destination (as in incoming host header)
   _httpClient.setUserAgent(F("ESP8266-Homie"));
-  _httpClient.begin(url);
+  _httpClient.begin(_wifiClient, url);
   // copy headers
   for (size_t i = 0; i < request->headers(); i++) {
     _httpClient.addHeader(request->headerName(i), request->header(i));

--- a/src/Homie/Boot/BootConfig.hpp
+++ b/src/Homie/Boot/BootConfig.hpp
@@ -42,6 +42,7 @@ class BootConfig : public Boot {
  private:
   AsyncWebServer _http;
   HTTPClient _httpClient;
+  WiFiClient _wifiClient;
   DNSServer _dns;
   uint8_t _ssidCount;
   bool _wifiScanAvailable;

--- a/src/Homie/Boot/BootNormal.cpp
+++ b/src/Homie/Boot/BootNormal.cpp
@@ -992,11 +992,11 @@ bool HomieInternals::BootNormal::__handleOTAUpdates(char* topic, char* payload, 
         // dynamically allocate some 800 bytes of memory for every payload chunk.
         size_t dec_len = bin_len > 1 ? 2 : 1;
         char c;
-        write_len = (size_t)base64_decode_block(payload, dec_len, &c, &_otaBase64State);
+        write_len = static_cast<size_t>(base64_decode_block(payload, dec_len, &c, &_otaBase64State));
         *payload = c;
 
         if (bin_len > 1) {
-          write_len += (size_t)base64_decode_block((const char*)payload + dec_len, bin_len - dec_len, payload + write_len, &_otaBase64State);
+          write_len += static_cast<size_t>(base64_decode_block((const char*)payload + dec_len, bin_len - dec_len, payload + write_len, &_otaBase64State));
         }
       } else {
         write_len = 0;


### PR DESCRIPTION
lint: fixed warning "Using C-style cast"
also fixed compatibility with Espressif 8266 platform core v3.0.0