### PR TITLE
Homie.isConfigured() now check only if valid (not load json)

### DIFF
--- a/src/Homie.cpp
+++ b/src/Homie.cpp
@@ -130,8 +130,11 @@ void HomieClass::setup() {
     _selectedHomieBootMode = HomieBootMode::NORMAL;
   }
 
+  // load and check config file
+  bool isConfigured = Interface::get().getConfig().load();
+
   // validate selected mode and fallback as needed
-  if (_selectedHomieBootMode == HomieBootMode::NORMAL && !Interface::get().getConfig().load()) {
+  if (_selectedHomieBootMode == HomieBootMode::NORMAL && !isConfigured) {
 #if HOMIE_CONFIG
     Interface::get().getLogger() << F("Configuration invalid. Using CONFIG MODE") << endl;
     _selectedHomieBootMode = HomieBootMode::CONFIGURATION;
@@ -308,7 +311,7 @@ HomieClass& HomieClass::setHomieBootModeOnNextBoot(HomieBootMode bootMode) {
 }
 
 bool HomieClass::isConfigured() {
-  return Interface::get().getConfig().load();
+  return Interface::get().getConfig().isValid();
 }
 
 bool HomieClass::isConnected() {


### PR DESCRIPTION
Avoid loading config each time want check if device is configured (calling `isConfigured()`).

Fix: Remove the spam message *"/homie/config.json doesn't exist"* in config mode, when put `isConfigured()` in `loop()`.

**notes:**
I have made some test and it seems work, but in this way you can call `Homie.isConfigured()` only after `Homie.setup()`.

...or maybe can be added something: 
```c++
bool HomieClass::isConfigured() {
  if(!_setupCalled) return Interface::get().getConfig().load();
  else return Interface::get().getConfig().isValid();
}
``` 