### PR TITLE
Rename freeheap $stats name

### DIFF
--- a/src/Homie/Boot/BootNormal.cpp
+++ b/src/Homie/Boot/BootNormal.cpp
@@ -195,7 +195,7 @@ void BootNormal::loop() {
     char freeHeapStr[20 + 1];
     utoa(freeHeap, freeHeapStr, 10);
     Interface::get().getLogger() << F("  • FreeHeap: ") << freeHeapStr << F("b") << endl;
-    uint16_t freeHeapPacketId = Interface::get().getMqttClient().publish(_prefixMqttTopic(PSTR("/$stats/free-heap")), 1, true, freeHeapStr);
+    uint16_t freeHeapPacketId = Interface::get().getMqttClient().publish(_prefixMqttTopic(PSTR("/$stats/freeheap")), 1, true, freeHeapStr);
 
     if (intervalPacketId != 0 && signalPacketId != 0 && uptimePacketId != 0 && freeHeapPacketId != 0) _statsTimer.tick();
     Interface::get().event.type = HomieEventType::SENDING_STATISTICS;


### PR DESCRIPTION
Following the https://github.com/homieiot/convention/blob/develop/extensions/documents/homie_legacy_stats_extension.md for Homie v4.0

Sorry for the previous PR (#719) but I have discovered now the existence of that extension (thanks to @qwandor [hodd PR#8](https://github.com/rroemhild/hodd/pull/8))