### PR TITLE
Free the char*-value before assigning a new strdup()'ed value

### DIFF
--- a/src/HomieSetting.cpp
+++ b/src/HomieSetting.cpp
@@ -106,7 +106,7 @@ bool HomieSetting<const char*>::isConstChar() const { return true; }
 template<>
 const char* HomieSetting<const char*>::getType() const { return "string"; }
 template<>
-void HomieSetting<const char*>::ffree() const { free((char*)_value); }
+void HomieSetting<const char*>::ffree() const { free(reinterpret_cast<char*>_value); }
 
 // Needed because otherwise undefined reference to
 template class HomieSetting<bool>;

--- a/src/HomieSetting.cpp
+++ b/src/HomieSetting.cpp
@@ -106,7 +106,7 @@ bool HomieSetting<const char*>::isConstChar() const { return true; }
 template<>
 const char* HomieSetting<const char*>::getType() const { return "string"; }
 template<>
-void HomieSetting<const char*>::ffree() const { free(reinterpret_cast<char*>_value); }
+void HomieSetting<const char*>::ffree() const { free(const_cast<char*>(_value)); }
 
 // Needed because otherwise undefined reference to
 template class HomieSetting<bool>;

--- a/src/HomieSetting.cpp
+++ b/src/HomieSetting.cpp
@@ -63,6 +63,7 @@ bool HomieSetting<T>::validate(T candidate) const {
 
 template <class T>
 void HomieSetting<T>::set(T value) {
+  ffree();
   _value = value;
   _provided = true;
 }
@@ -83,21 +84,29 @@ template<>
 bool HomieSetting<bool>::isBool() const { return true; }
 template<>
 const char* HomieSetting<bool>::getType() const { return "bool"; }
+template<>
+void HomieSetting<bool>::ffree() const {}
 
 template<>
 bool HomieSetting<long>::isLong() const { return true; }
 template<>
 const char* HomieSetting<long>::getType() const { return "long"; }
+template<>
+void HomieSetting<long>::ffree() const {}
 
 template<>
 bool HomieSetting<double>::isDouble() const { return true; }
 template<>
 const char* HomieSetting<double>::getType() const { return "double"; }
+template<>
+void HomieSetting<double>::ffree() const {}
 
 template<>
 bool HomieSetting<const char*>::isConstChar() const { return true; }
 template<>
 const char* HomieSetting<const char*>::getType() const { return "string"; }
+template<>
+void HomieSetting<const char*>::ffree() const { free((char*)_value); }
 
 // Needed because otherwise undefined reference to
 template class HomieSetting<bool>;

--- a/src/HomieSetting.hpp
+++ b/src/HomieSetting.hpp
@@ -61,6 +61,7 @@ class HomieSetting : public HomieInternals::IHomieSetting {
   bool isLong() const;
   bool isDouble() const;
   bool isConstChar() const;
+	void ffree() const;
 
   const char* getType() const;
 };

--- a/src/HomieSetting.hpp
+++ b/src/HomieSetting.hpp
@@ -61,7 +61,7 @@ class HomieSetting : public HomieInternals::IHomieSetting {
   bool isLong() const;
   bool isDouble() const;
   bool isConstChar() const;
-	void ffree() const;
+  void ffree() const;
 
   const char* getType() const;
 };


### PR DESCRIPTION
If you're using the customizable and optional "settings" within the config.json, every time `Homie.isConfigured()` is called, some heap memory is lost to a `strdup()`'ed variable.

The variable is created via a `strdup()` at [Config.cpp,141](https://github.com/homieiot/homie-esp8266/blob/8e905f0444f322804b1bec9f4694571c6df736a4/src/Homie/Config.cpp#L141) and saved at [HomieSetting.cpp,66](https://github.com/homieiot/homie-esp8266/blob/8e905f0444f322804b1bec9f4694571c6df736a4/src/HomieSetting.cpp#L66).

This PR adds a new function `ffree()` to every template, it only contains actual code for the `const char*`-Setting.

I have several "custom" settings in the config.json and I'm calling `Homie.isConfigured()` frequently. I noticed that the free heap space kept decreasing, which led to a forced reboot after a while.