### PR TITLE
Fix Config.cpp cast warnings

### DIFF
--- a/src/Homie/Config.cpp
+++ b/src/Homie/Config.cpp
@@ -188,9 +188,9 @@ void Config::setHomieBootModeOnNextBoot(HomieBootMode bootMode) {
       return;
     }
 
-    bootModeFile.printf("#%d", bootMode);
+    bootModeFile.printf("#%d", static_cast<int>(bootMode));
     bootModeFile.close();
-    Interface::get().getLogger().printf("Setting next boot mode to %d\n", bootMode);
+    Interface::get().getLogger().printf("Setting next boot mode to %d\n", static_cast<int>(bootMode));
   }
 }
 


### PR DESCRIPTION
There were two warnings caused by implicit `HomieBootMode` to `int` casts in `Config.cpp`.

<details>
<summary>Warnings</summary>

```
(...)\Config.cpp:191:28: warning: format '%d' expects argument of type 'int', but argument 3 has type 'HomieBootMode' [-Wformat=]
  191 |     bootModeFile.printf("#%d", bootMode);

(...)\Config.cpp:193:69: warning: format '%d' expects argument of type 'int', but argument 3 has type 'HomieBootMode' [-Wformat=]
  193 |     Interface::get().getLogger().printf("Setting next boot mode to %d\n", bootMode);
```

</details>

Explicitly casting to `int` solved the issue.