### PR TITLE
#744 defensivly own char* values so freeing them is safe

### DIFF
--- a/src/Homie/Config.cpp
+++ b/src/Homie/Config.cpp
@@ -138,7 +138,7 @@ bool Config::load() {
         setting->set(reqSetting.as<double>());
       } else if (iSetting->isConstChar()) {
         HomieSetting<const char*>* setting = static_cast<HomieSetting<const char*>*>(iSetting);
-        setting->set(strdup(reqSetting.as<const char*>()));
+        setting->set(reqSetting.as<const char*>());
       }
     }
   }

--- a/src/HomieSetting.cpp
+++ b/src/HomieSetting.cpp
@@ -63,7 +63,6 @@ bool HomieSetting<T>::validate(T candidate) const {
 
 template <class T>
 void HomieSetting<T>::set(T value) {
-  ffree();
   _value = value;
   _provided = true;
 }
@@ -84,29 +83,38 @@ template<>
 bool HomieSetting<bool>::isBool() const { return true; }
 template<>
 const char* HomieSetting<bool>::getType() const { return "bool"; }
-template<>
-void HomieSetting<bool>::ffree() const {}
 
 template<>
 bool HomieSetting<long>::isLong() const { return true; }
 template<>
 const char* HomieSetting<long>::getType() const { return "long"; }
-template<>
-void HomieSetting<long>::ffree() const {}
 
 template<>
 bool HomieSetting<double>::isDouble() const { return true; }
 template<>
 const char* HomieSetting<double>::getType() const { return "double"; }
-template<>
-void HomieSetting<double>::ffree() const {}
 
 template<>
 bool HomieSetting<const char*>::isConstChar() const { return true; }
 template<>
 const char* HomieSetting<const char*>::getType() const { return "string"; }
 template<>
-void HomieSetting<const char*>::ffree() const { free(const_cast<char*>(_value)); }
+HomieSetting<const char*>& HomieSetting<const char*>::setDefaultValue(const char* defaultValue) {
+  //free any potentially prior set value
+  free(const_cast<char*>(_value));
+  //duplicate the value, so we own it, and might free when required
+  _value = strdup(defaultValue);;
+  _required = false;
+  return *this;
+}
+template<>
+void HomieSetting<const char*>::set(const char* value) {
+  //free any potentially prior set value (that was copied)
+  free(const_cast<char*>(_value));
+  //duplicate the value, so we own it, and might free when required
+  _value = strdup(value);
+  _required = false;
+}
 
 // Needed because otherwise undefined reference to
 template class HomieSetting<bool>;


### PR DESCRIPTION
Hey, I think this might do (at least it works on my device ;)

Basically when getting a value (and only for the char* template) do the strdup internally and on all _value setting apis