### PR TITLE
Fix AsyncTCP double inclusion

### DIFF
--- a/library.json
+++ b/library.json
@@ -41,7 +41,16 @@
       "version": "^2.1.0"
     },
     {
-      "name": "ESP Async WebServer"
+      "name": "ESPAsyncTCP",
+      "version": "1.2.0"
+    },
+    {
+      "name": "ESP Async WebServer",
+      "version": "1.2.3",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/me-no-dev/ESPAsyncWebServer.git"
+      }
     }
   ],
   "export": {


### PR DESCRIPTION
Homie did not compile (Tested on PlatformIO with ESp32) due to a dependency issue (AsyncTCP double inclusion).
This was solved by switching ESP Async WebServer to me-no-dev version.

Probybly, this is related to #678.